### PR TITLE
DIGG-496: Updating check for sandbox environment

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -34,7 +34,7 @@ REACT_APP_SCREEN9_API_TOKEN=secret
 # IMAGE_DOMAIN=dev.beta.graphql.dataportal.dev1.se
 # REACT_APP_MEDIA_BASE_URL=https://dev.beta.strapi.dataportal.dev1.se
 
-## Connect to production backend (beta.dataportal.se).
+## Connect to production backend (dataportal.se).
 APOLLO_URL=https://graphql.digg.se/
 REACT_APP_APOLLO_URL=https://graphql.digg.se/
 IMAGE_DOMAIN=graphql.digg.se

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -76,7 +76,7 @@ function Dataportal({ Component, pageProps }: DataportalenProps) {
   const { asPath } = useRouter();
   const { t, lang } = useTranslation();
   // Put shared props into state to persist between pages that doesn't use getStaticProps
-  const [env, setEnv] = useState<EnvSettings>(SettingsUtil.create());
+  const [env, setEnv] = useState<EnvSettings | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [matomoActivated, setMatomoActivated] = useState<boolean>(true);
   const [openSideBar, setOpenSideBar] = useState(false);
@@ -94,13 +94,13 @@ function Dataportal({ Component, pageProps }: DataportalenProps) {
 
   useEffect(() => {
     if (typeof window !== "undefined") {
-      const clienthost = window?.location?.host || "";
-
+      const isSandbox = window.location.host.includes("sandbox");
       //if host is run from sandbox, load that environment and disable matomo
-      if (clienthost?.includes("sandbox")) {
+      if (isSandbox) {
         setEnv(new Settings_Sandbox());
-        //disable matomo
         setMatomoActivated(false);
+      } else {
+        setEnv(SettingsUtil.create());
       }
     }
     document.documentElement.classList.add("no-focus-outline");
@@ -131,6 +131,10 @@ function Dataportal({ Component, pageProps }: DataportalenProps) {
     }
     setImageHero(heroImage);
   }, [pathname]);
+
+  if (!env) {
+    return null;
+  }
 
   return (
     <ApolloProvider client={client}>


### PR DESCRIPTION
# Pull Request Description

Small check to make sure that if the environment is sandbox that it doesn't defaults to prod settings when hard refreshing.
I haven't found where the variable for this is set in production, it seems like the environment variables for production and sandbox is the same so there wasn't any way to change the REACT_APP_RUNTIME_ENV to sandbox for the sandbox environment.

Fixes #(issue)

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
