### PR TITLE
Get the entire raw pathname for locale detection, preventing redirection loops (resolves #569)

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -15,7 +15,10 @@ function getLocale(request: NextRequest): string {
 }
 
 export function middleware(request: NextRequest) {
-  const pathname = request.nextUrl.pathname;
+  // request.nextUrl.pathname strips the locale,
+  // Use the request.url string to extract the
+  // pathname which includes the locale prefix
+  const pathname = new URL(request.url).pathname;
 
   // Check if the pathname already has a locale
   const pathnameHasLocale = i18n.locales.some(


### PR DESCRIPTION
# Pull Request Description

Due to pathname automatically being stripped from the locale in `request.nextUrl`, the site got into an infinite redirection loop when the browser requested a non-default locale. This PR extracts the pathname from the full `request.url` string and stops the loop from happening.

Fixes #569 

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
