### PR TITLE
DIGG-565: Updating search to include query on organisation and small design improvements

### DIFF
--- a/features/entryscape/concept-page/index.tsx
+++ b/features/entryscape/concept-page/index.tsx
@@ -51,7 +51,7 @@ export const ConceptPage: FC = () => {
         <div className="flex w-full max-w-md flex-col">
           {entry.organisationLink ? (
             <Link
-              className="mb-lg text-lg font-normal text-green-600 hover:!no-underline"
+              className="mb-lg w-fit text-lg font-normal text-green-600 hover:!no-underline"
               href={entry.organisationLink}
             >
               {entry.publisher}

--- a/features/entryscape/dataset-explore-api-page/index.tsx
+++ b/features/entryscape/dataset-explore-api-page/index.tsx
@@ -99,7 +99,7 @@ export const DataSetExploreApiPage: FC<{
           {/* Publisher */}
           {entry.organisationLink ? (
             <Link
-              className="mb-lg text-lg font-normal text-green-600 hover:!no-underline"
+              className="mb-lg w-fit text-lg font-normal text-green-600 hover:!no-underline"
               href={entry.organisationLink}
             >
               {entry.publisher}

--- a/features/entryscape/dataset-page/index.tsx
+++ b/features/entryscape/dataset-page/index.tsx
@@ -73,7 +73,7 @@ export const DatasetPage: FC = () => {
             <div className="mb-md flex flex-col gap-md">
               {entry.organisationLink ? (
                 <Link
-                  className="text-lg font-normal text-green-600 hover:!no-underline"
+                  className="w-fit text-lg font-normal text-green-600 hover:!no-underline"
                   href={entry.organisationLink}
                 >
                   {entry.publisher}

--- a/features/entryscape/specification-page/index.tsx
+++ b/features/entryscape/specification-page/index.tsx
@@ -64,7 +64,7 @@ export const SpecificationPage: FC = () => {
             {entry.organisationLink ? (
               <Link
                 data-test-id="publisher"
-                className="mb-lg text-lg font-normal text-green-600 hover:!no-underline"
+                className="mb-lg w-fit text-lg font-normal text-green-600 hover:!no-underline"
                 href={entry.organisationLink}
               >
                 {entry.publisher}

--- a/utilities/entryscape/blocks/datasets.ts
+++ b/utilities/entryscape/blocks/datasets.ts
@@ -187,7 +187,7 @@ export const datasetBlocks = (
       block: "aboutDataset",
       extends: "template",
       template:
-        '<div class="about_dataset">' +
+        '<div class="about_dataset space-y-lg">' +
         '<div class="view_metadata_group">' +
         '{{viewMetadata template="dcat:Dataset" filterpredicates="' +
         filterAllExceptContactAndLandingPage.join(",") +

--- a/utilities/entrystore/entrystore.service.ts
+++ b/utilities/entrystore/entrystore.service.ts
@@ -999,14 +999,6 @@ export class EntrystoreService {
         .find(entry.getResourceURI(), "dcat:inSeries")
         .map((stmt: { getValue: () => string }) => stmt.getValue());
 
-      const test = await this.entryStore
-        .newSolrQuery()
-        .publicRead(true)
-        .uriFacet("foaf:name", true)
-        .list();
-      console.log("test", test);
-      console.log("test", test.getFacets());
-
       const datasetSeriesEntries =
         await this.entryStoreUtil.loadEntriesByResourceURIs(
           datasetSeriesUris,

--- a/utilities/entrystore/entrystore.service.ts
+++ b/utilities/entrystore/entrystore.service.ts
@@ -297,6 +297,7 @@ export class EntrystoreService {
         title: query,
         description: query,
         "tag.literal": query,
+        "related.metadata.predicate.literal.893797ba": query, // This searches for the name of the publisher
         all: query,
       });
     }
@@ -997,6 +998,14 @@ export class EntrystoreService {
       const datasetSeriesUris = metadata
         .find(entry.getResourceURI(), "dcat:inSeries")
         .map((stmt: { getValue: () => string }) => stmt.getValue());
+
+      const test = await this.entryStore
+        .newSolrQuery()
+        .publicRead(true)
+        .uriFacet("foaf:name", true)
+        .list();
+      console.log("test", test);
+      console.log("test", test.getFacets());
 
       const datasetSeriesEntries =
         await this.entryStoreUtil.loadEntriesByResourceURIs(


### PR DESCRIPTION
# Pull Request Description
Adding query search to work for organisations name.
Also adding spacing in aboutDataset section.
Adjusting organisations link to only take up the necessary width, was annoying to klick on an empty area and be redirected to another side.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
