### PR TITLE
Update link generation logic in specification.ts

### DIFF
--- a/utilities/entryscape/blocks/specification.ts
+++ b/utilities/entryscape/blocks/specification.ts
@@ -17,7 +17,7 @@ export const specificationBlocks = (t: Translate, iconSize: number) => [
       '<span class="block mb-md">{{prop "prof:hasRole" class="type" render="label"}}</span>' +
       '<div>{{ text content="${skos:definition}" }}</div>' +
       '<div class="flex justify-between items-end md:items-center mt-md md:mt-lg gap-lg">' +
-      '<a href="{{resourceURI}}">' +
+      '<a href="{{#ifprop "prof:hasArtifact"}}{{prop "prof:hasArtifact"}}{{/ifprop}}{{#ifprop "prof:hasArtifact" invert=true}}{{resourceURI}}{{/ifprop}}">' +
       '<span class="button button--primary button--large text-white">' +
       t("pages|specification_page$specification_download") +
       '<svg xmlns="http://www.w3.org/2000/svg" width="' +


### PR DESCRIPTION
# Pull Request Description

Adds logic which makes use of `prof:hasArtifact` for the Resource Descriptor link when such a property is present.

This change is introduced in preparation for an upcomming data change where the current links will be migrated to the `prof:hasArtifact` property.

The change can be tested at https://www-sandbox.dataportal.se/specifications/inspecTest/midSpec:
* the "dcterms vocabulary" resource uses the current pattern and the expected url is https://www.dublincore.org/specifications/dublin-core/dcmi-terms/dublin_core_terms.ttl
* the "example vocab" resource uses the new pattern, and the expected url is https://example.com/RDuri2Artifact

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
