### PR TITLE
Phase 3 part a

### DIFF
--- a/app/[locale]/error.tsx
+++ b/app/[locale]/error.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Locale-scoped error boundary for the App Router. Caught here, errors do
+ * not propagate up to `app/global-error.tsx` (which only triggers on
+ * crashes inside the root layout).
+ */
+export default function LocaleError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="mx-auto max-w-lg px-md py-xl">
+      <h1 className="mb-md text-2xl font-semibold">Något gick fel</h1>
+      <p className="mb-lg text-textPrimary">{error.message}</p>
+      <button
+        type="button"
+        className="rounded border border-borderPrimary px-md py-sm"
+        onClick={() => reset()}
+      >
+        Försök igen
+      </button>
+    </div>
+  );
+}

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -1,0 +1,85 @@
+import { headers } from "next/headers";
+import { notFound } from "next/navigation";
+import Script from "next/script";
+import { getMessages, setRequestLocale } from "next-intl/server";
+import type { ReactNode } from "react";
+
+import { AppRouterProviders } from "@/components/providers";
+import { isAppLocale, routing } from "@/i18n/routing";
+import { generateRandomKey } from "@/utilities/key-generator";
+
+import "@/styles/main.css";
+
+/**
+ * Pre-render every locale at build time. Without this, every page under
+ * `app/[locale]/...` would be dynamic.
+ */
+export function generateStaticParams() {
+  return routing.locales.map((locale) => ({ locale }));
+}
+
+/**
+ * Server-rendered locale shell. Owns:
+ *  - `<html lang>` / `<body>` (pulled out of `pages/_document.tsx` once
+ *    every route lives under `app/`).
+ *  - `/__ENV.js` injection so client components reading `react-env` get
+ *    runtime config before they hydrate.
+ *  - CSP nonce bridge from `proxy.ts` (`x-nonce` header) to client scripts.
+ *  - The `<head>` link/preconnect tags previously in `pages/_document.tsx`.
+ *
+ * Each `app/[locale]/.../page.tsx` rendered through this layout is
+ * pre-rendered per locale via `generateStaticParams`.
+ */
+export default async function LocaleLayout({
+  children,
+  params,
+}: {
+  children: ReactNode;
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+
+  if (!isAppLocale(locale)) {
+    notFound();
+  }
+
+  setRequestLocale(locale);
+
+  const [messages, requestHeaders] = await Promise.all([
+    getMessages(),
+    headers(),
+  ]);
+
+  // `proxy.ts` sets `x-nonce` per request. Fall back to a freshly minted
+  // nonce so a request that bypassed middleware (e.g. a static prerender
+  // pass) still ships with CSP coverage.
+  const nonce = requestHeaders.get("x-nonce") ?? generateRandomKey(32);
+
+  return (
+    <html lang={locale} data-scroll-behavior="smooth">
+      <head>
+        <Script src="/__ENV.js" strategy="beforeInteractive" nonce={nonce} />
+        <link
+          rel="stylesheet"
+          href="https://cdn.screen9.com/players/amber-player.css"
+        />
+        <link
+          rel="preconnect"
+          href="https://editera.dataportal.se"
+          crossOrigin="anonymous"
+        />
+        <link
+          rel="preconnect"
+          href="https://admin.dataportal.se"
+          crossOrigin="anonymous"
+        />
+        <meta name="theme-color" content="#FBF2F0" />
+      </head>
+      <body className="font-ubuntu text-md text-textPrimary">
+        <AppRouterProviders locale={locale} messages={messages} nonce={nonce}>
+          {children}
+        </AppRouterProviders>
+      </body>
+    </html>
+  );
+}

--- a/app/[locale]/not-found.tsx
+++ b/app/[locale]/not-found.tsx
@@ -1,0 +1,22 @@
+import Link from "next/link";
+
+/**
+ * Locale-scoped 404 for the App Router. Pages still owned by `pages/`
+ * continue to use `pages/404.tsx`; the two routers never collide on a
+ * single request.
+ */
+export default function LocaleNotFound() {
+  return (
+    <div className="mx-auto max-w-lg px-md py-xl">
+      <h1 className="mb-md text-2xl font-semibold">404</h1>
+      <p className="mb-lg text-textPrimary">
+        Sidan finns inte. (App Router — sidor som fortfarande ligger i{" "}
+        <code className="rounded bg-bgSecondary px-1">pages/</code> hanteras
+        där.)
+      </p>
+      <Link href="/" className="text-lg underline">
+        Till startsidan
+      </Link>
+    </div>
+  );
+}

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+/**
+ * Global error boundary — only triggers if something throws inside
+ * `app/layout.tsx` itself (i.e. before `[locale]/error.tsx` can catch it).
+ * Must declare its own `<html>` / `<body>` because the root layout that
+ * normally provides them has crashed.
+ */
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <html lang="sv">
+      <body className="font-ubuntu text-md">
+        <div style={{ maxWidth: 480, margin: "4rem auto", padding: "0 1rem" }}>
+          <h1>Något gick fel</h1>
+          <p>{error.message}</p>
+          <button type="button" onClick={() => reset()}>
+            Försök igen
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react";
+
+/**
+ * Root App Router layout. Intentionally a passthrough — `app/[locale]/layout.tsx`
+ * owns the `<html lang>` + `<body>` + `<head>` so we can render
+ * `<html lang={locale}>` dynamically per request. This file exists only to
+ * satisfy Next.js's requirement of a root layout.
+ *
+ * `pages/_document.tsx` continues to define `<html>` / `<body>` for the
+ * Pages Router; the two routers never collide on a single request.
+ */
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/components/blocks/fortroendemodellen-v2/index.tsx
+++ b/components/blocks/fortroendemodellen-v2/index.tsx
@@ -118,7 +118,7 @@ export const FortroendemodellenFrom = () => {
 
     const elements = formData.elements;
     SetupPages(elements as FormTypes[]);
-    GetLocalstorageData(setFormDataArray, elements, pathname);
+    GetLocalstorageData(setFormDataArray, elements, pathname ?? "");
   }, [formData, pathname]);
 
   const SetupPages = (data: FormTypes[]) => {

--- a/components/form/form-generate-pdf/index.tsx
+++ b/components/form/form-generate-pdf/index.tsx
@@ -33,7 +33,7 @@ export const FormGeneratePDF: FC<Props> = ({ formDataArray, blocks }) => {
         onClick={(e) => {
           GeneratePDF(e, iframeRef, formDataArray);
 
-          const url = pathname;
+          const url = pathname ?? "";
           const urlArray = url.split("/");
           const curPath = urlArray[urlArray.length - 1];
           const pathsToIgnore = ["uppfoljning", "infor-utveckling"];

--- a/components/navigation/container-nav/index.tsx
+++ b/components/navigation/container-nav/index.tsx
@@ -70,7 +70,7 @@ export const ContainerNav: FC<ContainerDpDwnProps> = ({ related }) => {
     if (url === related[0].slug || url.endsWith(related[0].slug)) {
       return pathname === url;
     } else {
-      return pathname.startsWith(url) && pathname !== related[0].slug;
+      return (pathname ?? "").startsWith(url) && pathname !== related[0].slug;
     }
   };
 

--- a/components/navigation/main-nav/index.tsx
+++ b/components/navigation/main-nav/index.tsx
@@ -28,7 +28,7 @@ const MainNav: FC<MainNavProps> = ({
   const [openSearch, setOpenSearch] = useState<boolean>(false);
   const [query, setQuery] = useState("");
   const pathname = usePathname();
-  const basePath = `/${pathname.split("/").splice(1, 1)[0]}`;
+  const basePath = `/${(pathname ?? "").split("/").splice(1, 1)[0]}`;
   const { t, lang } = useTranslation();
   const ref = useClickOutside<HTMLDivElement>(() => setOpenSearch(false));
   const formRef = useRef<HTMLFormElement>(null);

--- a/components/navigation/sidebar/sidebar-link/index.tsx
+++ b/components/navigation/sidebar/sidebar-link/index.tsx
@@ -57,7 +57,7 @@ const MenuLink: FC<MenuLinkProps> = ({
 }) => {
   const { t } = useTranslation();
   const pathname = usePathname();
-  const basePath = `/${pathname.split("/").splice(1, 1)[0]}`;
+  const basePath = `/${(pathname ?? "").split("/").splice(1, 1)[0]}`;
   const vw = window.innerWidth;
 
   const isActive =
@@ -131,7 +131,7 @@ export const SidebarLink: FC<
   const [open, setOpen] = useState(false);
   const { iconSize } = useContext(SettingsContext);
   const pathname = usePathname();
-  const basePath = `/${pathname.split("/").splice(1, 1)[0]}`;
+  const basePath = `/${(pathname ?? "").split("/").splice(1, 1)[0]}`;
 
   useEffect(() => {
     if (!openSideBar && list) {

--- a/components/providers.tsx
+++ b/components/providers.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import reactenv from "@beam-australia/react-env";
+import type { AbstractIntlMessages } from "next-intl";
+import { NextIntlClientProvider } from "next-intl";
+import { type ReactNode, useEffect, useState } from "react";
+
+import { type EnvSettings, SettingsUtil } from "@/env";
+import { Settings_Sandbox } from "@/env/settings.sandbox";
+import { MatomoProvider } from "@/lib/matomo";
+import {
+  type LayoutState,
+  LayoutStateProvider,
+} from "@/providers/layout-state-provider";
+import { LocalStoreProvider } from "@/providers/local-store-provider";
+import {
+  defaultSettings,
+  SettingsProvider,
+} from "@/providers/settings-provider";
+
+interface AppRouterProvidersProps {
+  children: ReactNode;
+  locale: string;
+  messages: AbstractIntlMessages;
+  /** CSP nonce stamped on the request by `proxy.ts`. */
+  nonce: string;
+  /** Optional initial breadcrumb / hero forwarded to `LayoutStateProvider`. */
+  initialBreadcrumb?: LayoutState["breadcrumbState"];
+  initialImageHero?: LayoutState["imageHero"];
+}
+
+/**
+ * Reads the persisted cookie-banner choice once, before mount. SSR-safe:
+ * returns `false` on the server (matches the Pages Router fallback in
+ * `pages/_app.tsx`).
+ */
+function readInitialConsent(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    const raw = localStorage.getItem("digg-store");
+    if (!raw) return false;
+    const parsed = JSON.parse(raw) as {
+      cookieSettings?: { analytic?: { accepted?: boolean } };
+    };
+    return parsed.cookieSettings?.analytic?.accepted === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * App Router client boundary. Wraps the four state providers any
+ * `app/[locale]/.../page.tsx` may consume:
+ *
+ *  - `NextIntlClientProvider`  — translations + formatters
+ *  - `SettingsProvider`        — `EnvSettings`, breadcrumb setter, Matomo site id
+ *  - `LocalStoreProvider`      — cookie-banner store backed by `localStorage`
+ *  - `MatomoProvider`          — script loading + page-view tracking
+ *  - `LayoutStateProvider`     — sidebar/settings dialog/hero/breadcrumb state
+ *
+ * `EnvSettings` is created client-side because it depends on
+ * `react-env` which reads `window.__beam_env` populated by `/__ENV.js`. The
+ * server layout injects that script with the CSP nonce *before* this
+ * provider hydrates, so the env is available on the first effect tick.
+ */
+export function AppRouterProviders({
+  children,
+  locale,
+  messages,
+  nonce,
+  initialBreadcrumb,
+  initialImageHero,
+}: AppRouterProvidersProps) {
+  const [env, setEnv] = useState<EnvSettings | null>(null);
+
+  useEffect(() => {
+    const isSandbox =
+      typeof window !== "undefined" && window.location.host.includes("sandbox");
+    setEnv(isSandbox ? new Settings_Sandbox() : SettingsUtil.create());
+  }, []);
+
+  // Until env hydrates, render with default (dev) settings so SSR markup
+  // matches and downstream code never sees `env === null`.
+  const resolvedEnv = env ?? SettingsUtil.getDefault();
+
+  const matomoDisabled =
+    process.env.NEXT_PUBLIC_DISABLE_MATOMO === "1" ||
+    resolvedEnv instanceof Settings_Sandbox;
+
+  return (
+    <NextIntlClientProvider locale={locale} messages={messages}>
+      <SettingsProvider
+        value={{
+          ...defaultSettings,
+          env: resolvedEnv,
+          matomoSiteId: reactenv("MATOMO_SITE_ID"),
+        }}
+      >
+        <LocalStoreProvider>
+          <LayoutStateProvider
+            initialBreadcrumb={initialBreadcrumb}
+            initialImageHero={initialImageHero}
+          >
+            <MatomoProvider
+              disabled={matomoDisabled}
+              initialConsent={readInitialConsent()}
+              nonce={nonce}
+            >
+              {children}
+            </MatomoProvider>
+          </LayoutStateProvider>
+        </LocalStoreProvider>
+      </SettingsProvider>
+    </NextIntlClientProvider>
+  );
+}

--- a/docs/next15-app-router-migration.md
+++ b/docs/next15-app-router-migration.md
@@ -68,24 +68,40 @@ Goal: remove Apollo without touching routing. This de-risks everything after.
 
 ## Phase 3 - Shell: `app/[locale]/layout.tsx` + providers + middleware
 
-Coexists with `pages/` - no route ported yet.
+Split into two PRs because each item has a very different blast radius:
 
-- Add `middleware.ts`:
-  - `next-intl/middleware` with `locales: ["sv", "en"]`, `defaultLocale: "sv"`, `localePrefix: "always"` (matches current `localeDetection: false` behavior), plus a localized `pathnames` map generated from `locales/sv/routes.json` / `locales/en/routes.json` so `/datasets` <-> `/data-apier` continues to work.
-  - Generate per-request CSP nonce, set on `x-nonce` request header.
-- Add `i18n/request.ts` (`next-intl` `getRequestConfig`) pointing at `locales/{locale}/{namespace}.json`. Flatten the custom `|` / `$` separators to standard nested JSON as part of this phase (one-time script; keys in code like `t("pages|startpage$search_placeholder")` get rewritten to `t("pages.startpage.search_placeholder")`).
-- Add `app/[locale]/layout.tsx` as a Server Component:
-  - Owns `<html lang>`, `<head>`, Matomo base tag, screen9 stylesheet, `/__ENV.js` script with nonce, `theme-color`, fonts.
-  - Reads nonce from `headers()`.
-  - Uses `NextIntlClientProvider` with messages from the request config.
-  - Static layout chrome (Header shell, Footer, Hero outer) stays server-rendered; interactive sub-components are Client Components.
-- Add `components/providers.tsx` marked `"use client"`:
-  - Wraps `SettingsProvider`, `LocalStoreProvider`, `MatomoProvider` (`@/lib/matomo`), `NextIntlClientProvider` for client consumers.
-- Move the shared layout state (`breadcrumbState`, `imageHero`, `openSideBar`, `settingsOpen`) out of `pages/_app.tsx` into a new `LayoutStateProvider` client context so it survives the move off `_app`.
-- Replace every `next/router` import with `next/navigation` (`useRouter`/`usePathname`/`useSearchParams`); replace `router.events.on("routeChangeComplete", ...)` (Matomo) with an effect on `[pathname, searchParams]`.
-- Add `app/[locale]/not-found.tsx`, `app/[locale]/error.tsx`, `app/global-error.tsx`.
+- **3a — Infra scaffold** (landed): `proxy.ts` + `next-intl` middleware, `i18n/{routing,request}.ts`, `app/layout.tsx` + `app/[locale]/layout.tsx`, `components/providers.tsx`, `LayoutStateProvider`, error/not-found shells, `pages/_app.tsx` refactor. Coexists with `pages/` — no route ported yet, no UI regression expected.
+- **3b — i18n key flatten + localized pathnames** (still pending): one-time codemod to flatten the `|` / `$` separators in `locales/**/*.json`, rewrite the ~330 `t("ns|key$sub")` call sites in 64 files, and wire `next-intl` `pathnames` from `routes.json` so `/datasets` ↔ `/en/data-apis` keeps working.
 
-At the end of Phase 3, `pages/` still owns every route. No UI should have regressed.
+### Phase 3a — what shipped (and pragmatic deviations from the original plan)
+
+- `proxy.ts`:
+  - `next-intl/middleware` with `locales: ["sv", "en"]`, `defaultLocale: "sv"`, `localePrefix: "as-needed"`. _Deviation:_ the original plan said `"always"` "matches current `localeDetection: false` behavior" — that's wrong. The legacy hand-rolled proxy stripped `/sv/` and only prefixed English (`as-needed` semantics). Switching to `"always"` would force `/sv/datasets` everywhere and break every existing URL/bookmark. We use `as-needed`.
+  - Per-request CSP nonce stamped on both the **request** header (so RSCs can read via `headers()`) and the **response** header. The locale layout falls back to a freshly minted nonce if the header is missing.
+- `i18n/routing.ts` exports a single `routing` object (DRY: middleware + request config + future `Link`/`navigation` helpers all consume it).
+- `i18n/request.ts`: `getRequestConfig` preloads all five namespaces (`common`, `pages`, `resources`, `routes`, `filters`) per locale. Messages keep their legacy `|`/`$` keys for now — the 3b codemod replaces them.
+- `next.config.mjs`: wrapped with `createNextIntlPlugin("./i18n/request.ts")`. The plugin order matters: `nextTranslate(withNextIntl(coreConfig), { turbopack: true })` — `next-intl` first so it doesn't see the legacy `i18n` key that `next-translate` injects.
+- Also added `serverExternalPackages: ["winston", "@alfalab/winston3-logstash-transport"]` to fix a Phase 2 fallout: `pages/_error.tsx → utilities/logger.ts → winston/...` was pulling Node-only `net`/`tls`/`fs` into the browser bundle under Turbopack. `_error.tsx` itself was tightened to dynamically import the logger behind `typeof window === "undefined"` with `webpackIgnore` / `turbopackIgnore` hints.
+- `app/layout.tsx`: minimal passthrough (`return children`). _Deviation:_ original plan implied a single root layout owning `<html>` — but `<html lang={locale}>` must be dynamic, so the locale layout below owns it instead. Documented Next-intl pattern.
+- `app/[locale]/layout.tsx` (RSC):
+  - Owns `<html lang>`, `<body>`, the screen9 stylesheet, preconnects, `theme-color`, and `/__ENV.js` (loaded `beforeInteractive` with the CSP nonce).
+  - `generateStaticParams()` pre-renders both locales.
+  - Validates `params.locale` and calls `notFound()` for unknown values.
+  - Wraps children in `<AppRouterProviders>`.
+- `components/providers.tsx` (`"use client"`, exports `AppRouterProviders`): wraps `NextIntlClientProvider`, `SettingsProvider`, `LocalStoreProvider`, `LayoutStateProvider`, `MatomoProvider`. `EnvSettings` is created client-side via `useEffect` because `react-env` reads `window.__beam_env` populated by `/__ENV.js`. Until env hydrates, `SettingsUtil.getDefault()` is used so SSR markup doesn't drift.
+- `providers/layout-state-provider/`: holds `settingsOpen`, `openSideBar`, `imageHero`, `breadcrumbState`, with both their setters. `pages/_app.tsx` reads from it via `useLayoutState()` and bridges `setBreadcrumb` into `SettingsContext` so the 14 existing pages that call `setBreadcrumb?.({...})` keep working unchanged.
+- `pages/_app.tsx`: split into `Dataportal` (outer, renders `LayoutStateProvider`) and `DataportalChrome` (inner, consumes the hook and renders `Settings/LocalStore/Matomo` + chrome). Top-level `useRouter()` from `next/router` removed — the hash effect now reads `props.router.asPath` instead.
+- `app/[locale]/not-found.tsx`, `app/[locale]/error.tsx`, `app/global-error.tsx`: minimal shells; `global-error.tsx` ships its own `<html>/<body>` because it triggers when the root layout itself crashes.
+
+_Pragmatic deviation — `next/router` → `next/navigation` sweep:_ the original plan said "replace every `next/router` import" in this phase. We deferred everything except `pages/_app.tsx`. The other ~38 callers all live inside Pages-Router-only files (`pages/`, `features/`); each will be ported alongside its page during Phase 4, when the surrounding component model also changes. Doing them eagerly here would make a 30-file mechanical PR that has no observable effect (all those files still render under `pages/` for now).
+
+### Phase 3b — still to do
+
+- One-time JSON codemod: `{"pages|startpage$heading": "..."}` → `{ "pages": { "startpage": { "heading": "..." } } }` for all five namespaces × two locales (~1200 lines).
+- `t()` codemod across all 64 callers: `t("ns|key$sub")` → `t("ns.key.sub")` (or split into `useTranslations("ns")` + `t("key.sub")` where the namespace is consistent within a file).
+- Add `pathnames` to `i18n/routing.ts` derived from `locales/{sv,en}/routes.json` so localized slugs (`/datasets` ↔ `/en/data-apis`, etc.) survive the App Router move. Build a generator so we keep a single source of truth.
+
+At the end of Phase 3 (3a + 3b), `pages/` still owns every route. No UI should have regressed.
 
 ## Phase 4 - Port routes family by family
 
@@ -182,8 +198,8 @@ lib/
 - [x] **Phase 1:** add `graphql/fetcher.ts` (`gqlFetch`) and port all `query-helpers` + `form-utils` call sites off Apollo.
 - [x] **Phase 1:** remove `ApolloProvider` from `_app`/`_document`, delete `graphql/client.ts`, drop `@apollo/client` + `apollo` deps, switch introspect to `graphql-codegen`.
 - [ ] **Phase 2:** upgrade to Next 16 / React 19 on the Pages Router, run Next codemods, fix `images.remotePatterns` and `fetch` cache defaults.
-- [ ] **Phase 3:** extend `proxy.ts` (next-intl + CSP nonce — the Phase 2 rename already moved `middleware.ts` to `proxy.ts`), add `i18n/request.ts`, `app/[locale]/layout.tsx`, `components/providers.tsx`, `LayoutStateProvider`, not-found/error pages; switch `next/router` -> `next/navigation`.
-- [ ] **Phase 3:** flatten locale JSON (drop `|` and `$` separators) and codemod every `t()` call; wire `next-intl` pathnames from `routes.json` for localized slugs.
+- [x] **Phase 3a:** extend `proxy.ts` (next-intl + CSP nonce), add `i18n/{routing,request}.ts`, `app/layout.tsx` + `app/[locale]/layout.tsx`, `components/providers.tsx`, `LayoutStateProvider`, not-found/error pages, refactor `pages/_app.tsx` onto `LayoutStateProvider`. _Per-page `next/router` → `next/navigation` sweep deferred to Phase 4._
+- [ ] **Phase 3b:** flatten locale JSON (drop `|` and `$` separators) and codemod every `t()` call (~330 calls across 64 files); wire `next-intl` `pathnames` from `routes.json` for localized slugs.
 - [ ] **Phase 4:** port static/API/sitemap routes to `app/` (healthcheck, auth, sitemap, 404).
 - [ ] **Phase 4:** port start/landing/container/list/form pages and CMS routes (nyheter, goda-exempel, stod-och-verktyg, [...containerSlug], fortroendemodellen tree).
 - [ ] **Phase 4:** port Entryscape route families one PR each (datasets, dataservice, concepts, specifications, terminology, organisations, metadatakvalitet, dataset-series, external*, drafts).

--- a/features/pages/form-page/index.tsx
+++ b/features/pages/form-page/index.tsx
@@ -76,7 +76,7 @@ export const FormPage: FC<Props> = ({ elements, module }) => {
     });
 
     SetupPages(elements as FormTypes[]);
-    GetLocalstorageData(setFormDataArray, elements, pathname);
+    GetLocalstorageData(setFormDataArray, elements, pathname ?? "");
   }, []);
 
   const SetupPages = (data: FormTypes[]) => {

--- a/i18n/request.ts
+++ b/i18n/request.ts
@@ -1,0 +1,40 @@
+import { getRequestConfig } from "next-intl/server";
+
+import { type AppLocale, isAppLocale, routing } from "./routing";
+
+/**
+ * Loads the same five locale namespaces (`common`, `pages`, `resources`,
+ * `routes`, `filters`) we use under `next-translate`. Messages keep their
+ * legacy `|`/`$` separator keys for now — the second Phase 3 PR will flatten
+ * the JSON and codemod every `t()` call site. Until then, App Router code
+ * that needs translations should reach into the namespace as a flat map.
+ */
+async function loadMessages(locale: AppLocale) {
+  const [common, pages, resources, routes, filters] = await Promise.all([
+    import(`../locales/${locale}/common.json`),
+    import(`../locales/${locale}/pages.json`),
+    import(`../locales/${locale}/resources.json`),
+    import(`../locales/${locale}/routes.json`),
+    import(`../locales/${locale}/filters.json`),
+  ]);
+
+  return {
+    common: common.default,
+    pages: pages.default,
+    resources: resources.default,
+    routes: routes.default,
+    filters: filters.default,
+  };
+}
+
+export default getRequestConfig(async ({ requestLocale }) => {
+  const resolved = await requestLocale;
+  const locale: AppLocale = isAppLocale(resolved)
+    ? resolved
+    : (routing.defaultLocale as AppLocale);
+
+  return {
+    locale,
+    messages: await loadMessages(locale),
+  };
+});

--- a/i18n/routing.ts
+++ b/i18n/routing.ts
@@ -1,0 +1,31 @@
+import { defineRouting } from "next-intl/routing";
+
+/**
+ * Shared `next-intl` routing config.
+ *
+ * `localePrefix: "as-needed"` mirrors the legacy `proxy.ts` behaviour:
+ * Swedish URLs stay unprefixed (`/datasets`), English under `/en/...`.
+ *
+ * `localeDetection: false` matches the legacy `i18n.js`; we never redirect
+ * based on the `Accept-Language` header.
+ *
+ * Localized **pathnames** (e.g. `/data-apier` ↔ `/en/data-apis`) are deferred
+ * to the second Phase 3 PR — adding them before any `app/[locale]/...` page
+ * exists would rewrite URLs to internal paths with no `page.tsx` to render.
+ */
+export const routing = defineRouting({
+  locales: ["sv", "en"],
+  defaultLocale: "sv",
+  localePrefix: "as-needed",
+  localeDetection: false,
+  localeCookie: false,
+});
+
+export type AppLocale = (typeof routing.locales)[number];
+
+export function isAppLocale(value: string | undefined): value is AppLocale {
+  return (
+    typeof value === "string" &&
+    (routing.locales as readonly string[]).includes(value)
+  );
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,3 +1,4 @@
+import createNextIntlPlugin from "next-intl/plugin";
 import nextTranslate from "next-translate-plugin";
 
 /** @type {import('next').NextConfig} */
@@ -41,56 +42,67 @@ const csp = [
   },
 ];
 
+// Plugin chain (apply order matters):
+//   1. `createNextIntlPlugin("./i18n/request.ts")` wires `next-intl` server config.
+//   2. `nextTranslate(..., { turbopack: true })` injects the legacy `i18n` key
+//      that `next-translate` (still used by `pages/`) requires. Applying
+//      `next-intl` first keeps it from seeing that key and erroring out with
+//      "An i18n property was found in your Next.js config".
 // `next-translate-plugin` requires `{ turbopack: true }` on Next 16 so it
 // registers its `t()` rewrite loader under Turbopack (the default bundler).
 // Without it, `t()` calls render as raw keys (e.g. `common|dataportal`).
 // NOTE: with turbopack: true the plugin strips any `webpack` config you pass,
 // so we express bundler-specific rules via `turbopack.rules` only.
-const nextConfig = nextTranslate(
-  {
-    turbopack: {
-      rules: {
-        "*.svg": {
-          loaders: ["@svgr/webpack"],
-          as: "*.js",
-        },
+
+const withNextIntl = createNextIntlPlugin("./i18n/request.ts");
+
+const coreNextConfig = {
+  turbopack: {
+    rules: {
+      "*.svg": {
+        loaders: ["@svgr/webpack"],
+        as: "*.js",
       },
     },
-    productionBrowserSourceMaps: true,
-    env: {
-      REVALIDATE_INTERVAL: process.env.REVALIDATE_INTERVAL,
-    },
-
-    staticPageGenerationTimeout: 240,
-
-    images: {
-      remotePatterns: [
-        {
-          protocol: "https",
-          hostname: process.env.IMAGE_DOMAIN || "localhost",
-        },
-        { protocol: "https", hostname: "bcdn.screen9.com" },
-      ],
-      deviceSizes: [640, 1080, 1200, 1920],
-      imageSizes: [128, 384],
-      dangerouslyAllowSVG: true,
-      minimumCacheTTL: 604800,
-    },
-
-    async headers() {
-      return [
-        {
-          source: "/(.*)",
-          headers: [...baseHeaders, ...csp],
-        },
-        {
-          source: "/",
-          headers: [...baseHeaders, ...csp],
-        },
-      ];
-    },
   },
-  { turbopack: true },
-);
+  // Keep Node-only deps out of the browser bundle. `winston` and the
+  // logstash transport import `net`/`tls`/`fs`; with Turbopack default in
+  // Next 16 there's no implicit `resolve.fallback: false` shim, so they
+  // crash the build when transitively imported from `pages/_error.tsx`.
+  serverExternalPackages: ["winston", "@alfalab/winston3-logstash-transport"],
+  productionBrowserSourceMaps: true,
+  env: {
+    REVALIDATE_INTERVAL: process.env.REVALIDATE_INTERVAL,
+  },
 
-export default nextConfig;
+  staticPageGenerationTimeout: 240,
+
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: process.env.IMAGE_DOMAIN || "localhost",
+      },
+      { protocol: "https", hostname: "bcdn.screen9.com" },
+    ],
+    deviceSizes: [640, 1080, 1200, 1920],
+    imageSizes: [128, 384],
+    dangerouslyAllowSVG: true,
+    minimumCacheTTL: 604800,
+  },
+
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: [...baseHeaders, ...csp],
+      },
+      {
+        source: "/",
+        headers: [...baseHeaders, ...csp],
+      },
+    ];
+  },
+};
+
+export default nextTranslate(withNextIntl(coreNextConfig), { turbopack: true });

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "meilisearch": "^0.27.0",
     "next": "16.2.4",
     "next-absolute-url": "^1.2.2",
+    "next-intl": "^4.9.1",
     "next-translate": "3.1.2",
     "node-fetch": "^3.2.10",
     "organisationsnummer": "^1.2.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,18 +2,14 @@ import reactenv from "@beam-australia/react-env";
 import type { AppContext, AppProps } from "next/app";
 import App from "next/app";
 import { usePathname } from "next/navigation";
-import { useRouter } from "next/router";
 import useTranslation from "next-translate/useTranslation";
-import { useEffect, useMemo, useState } from "react";
+import { type FC, useEffect, useMemo, useState } from "react";
 
 import { Footer } from "@/components/layout/footer";
 import { Header } from "@/components/layout/header";
 import { Hero } from "@/components/layout/hero";
 import { MetaData } from "@/components/meta-data";
-import {
-  type BreadcrumbProps,
-  Breadcrumbs,
-} from "@/components/navigation/breadcrumbs";
+import { Breadcrumbs } from "@/components/navigation/breadcrumbs";
 import { Sidebar } from "@/components/navigation/sidebar";
 import {
   SkipToContent,
@@ -29,6 +25,10 @@ import type {
 } from "@/graphql/__generated__/operations";
 import { MatomoProvider } from "@/lib/matomo";
 import {
+  LayoutStateProvider,
+  useLayoutState,
+} from "@/providers/layout-state-provider";
+import {
   type LocalStore,
   LocalStoreProvider,
 } from "@/providers/local-store-provider";
@@ -40,9 +40,9 @@ import type { SubLink, SubLinkFooter } from "@/types/global";
 import {
   type DataportalPageProps,
   getNavigationData,
-  linkBase,
   resolvePage,
 } from "@/utilities";
+import { initBreadcrumb } from "@/utilities/layout-breadcrumb";
 import "@/styles/main.css";
 
 const getCookiesAccepted = () => {
@@ -64,50 +64,49 @@ interface DataportalenProps extends AppProps {
   nonce: string;
 }
 
-export const initBreadcrumb = {
-  name: "",
-  crumbs: [{ name: "start", link: { ...linkBase, link: "/" } }],
-};
+/** Re-exported for backwards compatibility with `pages/404.tsx` etc. */
+export { initBreadcrumb };
 
-/**
- * focuses on element with id provided from path
- * @param pathWithHash url path along with hash
- */
+/** Focuses on element with id provided from path. */
 const onHash = (pathWithHash: string) => {
   const hashIndex = pathWithHash.indexOf("#");
   const hash = pathWithHash.substring(hashIndex + 1);
   skipToElement(hash);
 };
 
-function Dataportal({
+/**
+ * Inner shell — runs inside `LayoutStateProvider` so it can read shared
+ * layout chrome state via the new hook. All page-level state that used to
+ * live as `useState` calls in this file now lives in the provider.
+ */
+const DataportalChrome: FC<DataportalenProps> = ({
   Component,
   pageProps,
+  router,
   navigationData: initialNavigationData,
-}: DataportalenProps) {
+}) => {
   const pathname = usePathname();
-  const { asPath } = useRouter();
   const { t, lang } = useTranslation();
-  // Put shared props into state to persist between pages that doesn't use getStaticProps
   const [env, setEnv] = useState<EnvSettings | null>(null);
-  const [settingsOpen, setSettingsOpen] = useState(false);
-  const [openSideBar, setOpenSideBar] = useState(false);
+  const {
+    settingsOpen,
+    setSettingsOpen,
+    openSideBar,
+    setOpenSideBar,
+    imageHero,
+    setImageHero,
+    breadcrumbState,
+    setBreadcrumb,
+  } = useLayoutState();
+
   const { seo, heading, heroImage, preamble } = resolvePage(
     pageProps as DataportalPageProps,
     lang,
     t,
   );
 
-  const [imageHero, setImageHero] = useState(heroImage);
-  const [breadcrumbState, setBreadcrumb] = useState<BreadcrumbProps>({
-    name: heading || "",
-    crumbs: [{ name: "start", link: { ...linkBase, link: "/" } }],
-  });
-
   const navigationData = useMemo(() => {
-    if (!initialNavigationData?.items?.length) {
-      return null;
-    }
-
+    if (!initialNavigationData?.items?.length) return null;
     return initialNavigationData?.items.find(
       (nav: NavigationDataFragment) => nav.locale === lang,
     );
@@ -142,15 +141,17 @@ function Dataportal({
     pathname === `/${t("routes|search-api$path")}` ? null : preamble;
 
   useEffect(() => {
-    if (asPath.includes("#")) {
-      onHash(asPath);
+    // `router.asPath` keeps fragment + query so we can detect `#hash`
+    // navigation. We avoid `useRouter()` from `next/router` at module top
+    // level to ease the eventual App Router move; `props.router` is the
+    // identical instance for any Pages Router page.
+    if (router?.asPath.includes("#")) {
+      onHash(router.asPath);
     }
     setImageHero(heroImage);
   }, [pathname]);
 
-  if (!env) {
-    return null;
-  }
+  if (!env) return null;
 
   return (
     <SettingsProvider
@@ -240,6 +241,14 @@ function Dataportal({
         </MatomoProvider>
       </LocalStoreProvider>
     </SettingsProvider>
+  );
+};
+
+function Dataportal(props: DataportalenProps) {
+  return (
+    <LayoutStateProvider initialBreadcrumb={initBreadcrumb}>
+      <DataportalChrome {...props} />
+    </LayoutStateProvider>
   );
 }
 

--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -1,26 +1,21 @@
 import type { NextPage } from "next";
 import NextErrorComponent, { type ErrorProps } from "next/error";
 
-import serverLogger from "../utilities/logger";
-
 interface AppErrorProps extends ErrorProps {
   err?: Error;
   hasGetInitialPropsRun?: boolean;
 }
 
 /**
- * Server application error page, uses logger instance on server rendering code
+ * Server application error page.
+ *
+ * The Winston-based logger lives in `utilities/logger.ts` and pulls in
+ * Node-only deps (`net`, `tls`, `fs`). Importing it at module scope used
+ * to crash the browser bundle under Next 16 / Turbopack (no implicit
+ * `resolve.fallback: false`). Logger calls are now `await import(...)`-ed
+ * lazily inside `getInitialProps`, which only ever runs on the server.
  */
-const AppError: NextPage<AppErrorProps> = ({
-  hasGetInitialPropsRun,
-  err,
-  statusCode,
-}) => {
-  if (!hasGetInitialPropsRun && err) {
-    const logger = serverLogger.getInstance();
-    logger.error([err.message, err.stack]);
-  }
-
+const AppError: NextPage<AppErrorProps> = ({ statusCode }) => {
   return <NextErrorComponent statusCode={statusCode} />;
 };
 
@@ -28,17 +23,27 @@ AppError.getInitialProps = async (ctx) => {
   const errorInitialProps: AppErrorProps =
     await NextErrorComponent.getInitialProps(ctx);
   errorInitialProps.hasGetInitialPropsRun = true;
-  if (ctx.err) {
-    const logger = serverLogger.getInstance();
-    logger.error([ctx.err.message, ctx.err.stack]);
 
-    return errorInitialProps;
+  // `getInitialProps` runs on both server and client; only load the
+  // Winston logger on the server. The `webpackIgnore` / `turbopackIgnore`
+  // hints stop the bundler from following this import into the client
+  // bundle (Winston pulls in `net`/`tls`/`fs`).
+  if (typeof window === "undefined") {
+    const { default: ServerLogger } = await import(
+      /* webpackIgnore: true */
+      /* turbopackIgnore: true */
+      "../utilities/logger"
+    );
+    const logger = ServerLogger.getInstance();
+
+    if (ctx.err) {
+      logger.error([ctx.err.message, ctx.err.stack]);
+    } else {
+      logger.error(
+        `_error.tsx getInitialProps missing data at path: ${ctx.asPath}`,
+      );
+    }
   }
-
-  const logger = serverLogger.getInstance();
-  logger.error(
-    `_error.tsx getInitialProps missing data at path: ${ctx.asPath}`,
-  );
 
   return errorInitialProps;
 };

--- a/providers/layout-state-provider/index.tsx
+++ b/providers/layout-state-provider/index.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import {
+  createContext,
+  type Dispatch,
+  type FC,
+  type ReactNode,
+  type SetStateAction,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+
+import type { BreadcrumbProps } from "@/components/navigation/breadcrumbs";
+import type {
+  GoodExampleDataFragment,
+  ImageFragment,
+  NewsItemDataFragment,
+} from "@/graphql/__generated__/operations";
+import { initBreadcrumb } from "@/utilities/layout-breadcrumb";
+
+/**
+ * Hero image shape — superset of all `pageProps.heroImage` variants returned
+ * from `resolvePage(...)` (`utilities/app.ts`). Kept loose so the provider
+ * doesn't pin itself to a single fragment.
+ */
+export type HeroImage =
+  | ImageFragment
+  | NewsItemDataFragment["image"]
+  | GoodExampleDataFragment["image"]
+  | null
+  | undefined;
+
+export interface LayoutState {
+  settingsOpen: boolean;
+  setSettingsOpen: Dispatch<SetStateAction<boolean>>;
+  openSideBar: boolean;
+  setOpenSideBar: Dispatch<SetStateAction<boolean>>;
+  imageHero: HeroImage;
+  setImageHero: Dispatch<SetStateAction<HeroImage>>;
+  breadcrumbState: BreadcrumbProps;
+  setBreadcrumb: Dispatch<SetStateAction<BreadcrumbProps>>;
+}
+
+const LayoutStateContext = createContext<LayoutState | null>(null);
+
+/**
+ * Holds shared layout chrome state: cookie-settings dialog open/closed,
+ * sidebar open/closed, hero image, and breadcrumbs. Lives in a single
+ * provider so it survives both the legacy `pages/_app.tsx` and the App
+ * Router `app/[locale]/layout.tsx` boundary.
+ */
+export const LayoutStateProvider: FC<{
+  children: ReactNode;
+  initialBreadcrumb?: BreadcrumbProps;
+  initialImageHero?: HeroImage;
+}> = ({ children, initialBreadcrumb, initialImageHero }) => {
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [openSideBar, setOpenSideBar] = useState(false);
+  const [imageHero, setImageHero] = useState<HeroImage>(
+    initialImageHero ?? null,
+  );
+  const [breadcrumbState, setBreadcrumb] = useState<BreadcrumbProps>(
+    initialBreadcrumb ?? initBreadcrumb,
+  );
+
+  const value = useMemo<LayoutState>(
+    () => ({
+      settingsOpen,
+      setSettingsOpen,
+      openSideBar,
+      setOpenSideBar,
+      imageHero,
+      setImageHero,
+      breadcrumbState,
+      setBreadcrumb,
+    }),
+    [settingsOpen, openSideBar, imageHero, breadcrumbState],
+  );
+
+  return (
+    <LayoutStateContext.Provider value={value}>
+      {children}
+    </LayoutStateContext.Provider>
+  );
+};
+
+export function useLayoutState(): LayoutState {
+  const ctx = useContext(LayoutStateContext);
+  if (!ctx) {
+    throw new Error("useLayoutState must be used within <LayoutStateProvider>");
+  }
+  return ctx;
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,74 +1,40 @@
 import type { NextRequest } from "next/server";
-import { NextResponse } from "next/server";
+import createMiddleware from "next-intl/middleware";
 
-import i18n from "./i18n";
+import { routing } from "./i18n/routing";
+import { generateRandomKey } from "./utilities/key-generator";
 
-/**
- * Determines the locale for the current request
- * Since localeDetection is false in i18n.js, we only use the locale from the URL
- * or fall back to the default locale (sv)
- */
-function getLocale(request: NextRequest): string {
-  // First check if the URL already has a locale
-  const pathname = request.nextUrl.pathname;
-  const pathnameLocale = i18n.locales.find(
-    (locale) => pathname.startsWith(`/${locale}/`) || pathname === `/${locale}`,
-  );
-  if (pathnameLocale) {
-    return pathnameLocale;
-  }
-
-  // Since localeDetection is false, we always return defaultLocale
-  return i18n.defaultLocale;
-}
+const handleI18n = createMiddleware(routing);
 
 /**
- * Proxy (formerly `middleware`, renamed in Next 16) for handling locale-based routing.
+ * Next 16 middleware (renamed `proxy.ts` per the Next 16 file convention).
  *
- * Rules:
- * 1. If URL contains default locale (sv), remove it
- * 2. If URL has no locale and it's not default locale, add it
- * 3. If URL already has a non-default locale, leave it as is
+ * Two responsibilities:
+ *  1. `next-intl` locale handling with `localePrefix: "as-needed"`: Swedish
+ *     stays unprefixed (`/datasets`), English under `/en/...`. Replaces the
+ *     hand-rolled redirect logic that used to live here.
+ *  2. Per-request CSP nonce: stamps `x-nonce` on both the **request** (so
+ *     server components in `app/[locale]/layout.tsx` can read it via
+ *     `headers()`) and the **response** (for any downstream consumer). The
+ *     `app/[locale]/layout.tsx` falls back to generating its own nonce if
+ *     this header is missing, so a cold-cache request never ships without
+ *     CSP coverage.
  */
 export function proxy(request: NextRequest) {
-  const pathname = request.nextUrl.pathname;
+  const nonce = generateRandomKey(32);
 
-  // Special handling for root path
-  if (pathname === "/") {
-    const locale = getLocale(request);
-    if (locale !== i18n.defaultLocale) {
-      return NextResponse.redirect(new URL(`/${locale}`, request.url));
-    }
-    return NextResponse.next();
-  }
+  // Mutating the incoming request headers makes them visible to downstream
+  // RSCs via `headers()` whenever the eventual NextResponse is a rewrite or
+  // pass-through (which is what `next-intl` returns for valid locales).
+  request.headers.set("x-nonce", nonce);
 
-  // Check if the pathname already has a locale
-  const pathnameHasLocale = i18n.locales.some(
-    (locale) => pathname.startsWith(`/${locale}/`) || pathname === `/${locale}`,
-  );
-
-  if (pathnameHasLocale) {
-    const currentLocale = i18n.locales.find(
-      (locale) =>
-        pathname.startsWith(`/${locale}/`) || pathname === `/${locale}`,
-    );
-
-    // If the URL contains the default locale (sv), remove it
-    if (currentLocale === i18n.defaultLocale) {
-      const newPathname = pathname.replace(`/${i18n.defaultLocale}`, "") || "/";
-      const newUrl = new URL(newPathname, request.url);
-      newUrl.search = request.nextUrl.search;
-      return NextResponse.redirect(newUrl);
-    }
-    // If the URL has a non-default locale, leave it as is
-    return NextResponse.next();
-  }
-
-  // Since localeDetection is false, we don't redirect based on browser locale
-  return NextResponse.next();
+  const response = handleI18n(request);
+  response.headers.set("x-nonce", nonce);
+  return response;
 }
 
 export const config = {
+  // Skip Next internals, static assets, and route handlers (`/api`).
   matcher: [
     "/((?!api|_next/static|_next/image|favicon.ico|__ENV.js|manifest.json|.*\\.(?:jpg|jpeg|gif|png|svg|woff|woff2)).*)",
     "/",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,13 +19,20 @@
     "paths": {
       "@/*": ["./*"],
       "types": ["cypress", "cy-verify-downloads"]
-    }
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
   "include": [
     "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
-    "pages/fortroendemodellen-obsolete/(index.ts)"
+    "pages/fortroendemodellen-obsolete/(index.ts)",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
   ],
   "exclude": ["node_modules"]
 }

--- a/utilities/layout-breadcrumb.ts
+++ b/utilities/layout-breadcrumb.ts
@@ -1,0 +1,13 @@
+import type { BreadcrumbProps } from "@/components/navigation/breadcrumbs";
+
+import { linkBase } from "./route-helpers";
+
+/**
+ * Default breadcrumb state used by both `pages/_app.tsx` (legacy) and the
+ * App Router `LayoutStateProvider`. Extracted to a single file so both
+ * routers stay in sync as the `app/` migration progresses.
+ */
+export const initBreadcrumb: BreadcrumbProps = {
+  name: "",
+  crumbs: [{ name: "start", link: { ...linkBase, link: "/" } }],
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1585,6 +1585,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@formatjs/fast-memoize@npm:3.1.2, @formatjs/fast-memoize@npm:^3.1.0":
+  version: 3.1.2
+  resolution: "@formatjs/fast-memoize@npm:3.1.2"
+  checksum: 10/cfe5a5974f3567d9b7f27b93d99d1bd755918c286e385b7f2354f7db69ec7408c5d7df77369745fb9e16816003f1b55da72bad1d5c53c7d11db16392f24f042c
+  languageName: node
+  linkType: hard
+
+"@formatjs/icu-messageformat-parser@npm:3.5.4, @formatjs/icu-messageformat-parser@npm:^3.4.0":
+  version: 3.5.4
+  resolution: "@formatjs/icu-messageformat-parser@npm:3.5.4"
+  dependencies:
+    "@formatjs/icu-skeleton-parser": "npm:2.1.4"
+  checksum: 10/aae4085f1f96db88f6bcf6264e6b3f2bba132fc248608a6d6e08b2afebe4a0aa2a92455e4c16576b0011caa20c517f9f3b2f79b70bd73df07ab150d0662cb161
+  languageName: node
+  linkType: hard
+
+"@formatjs/icu-skeleton-parser@npm:2.1.4":
+  version: 2.1.4
+  resolution: "@formatjs/icu-skeleton-parser@npm:2.1.4"
+  checksum: 10/e9452743b3427f52ce376fa3c405978daf4b285cdb15f2d2ec9034c70e664314fb87218b1657df1be570e4227fb6421a1095540b4b704c5edda609d8a90cc526
+  languageName: node
+  linkType: hard
+
+"@formatjs/intl-localematcher@npm:^0.8.1":
+  version: 0.8.3
+  resolution: "@formatjs/intl-localematcher@npm:0.8.3"
+  dependencies:
+    "@formatjs/fast-memoize": "npm:3.1.2"
+  checksum: 10/f0873de7b0cef48ac22c7dbc1dc06bad5c1f2e7f51e151bdc0d83e61a1a864a69079a3db5469a1fb6809fc39d4d24a9a9186a3ed1e7de07c0e5b6e872881ca2b
+  languageName: node
+  linkType: hard
+
 "@graphql-codegen/add@npm:^3.2.1":
   version: 3.2.3
   resolution: "@graphql-codegen/add@npm:3.2.3"
@@ -3170,6 +3202,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@schummar/icu-type-parser@npm:1.21.5":
+  version: 1.21.5
+  resolution: "@schummar/icu-type-parser@npm:1.21.5"
+  checksum: 10/4e83edf93bf49c414d9e2f5bb0457dfd012586d4e24f3850a4cc5b6a18c5329868e8a4b1cb0d4ad8490f175fd21d00229213eb9b2e799809015d85788e567139
+  languageName: node
+  linkType: hard
+
 "@svgr/babel-plugin-add-jsx-attribute@npm:8.0.0":
   version: 8.0.0
   resolution: "@svgr/babel-plugin-add-jsx-attribute@npm:8.0.0"
@@ -3820,12 +3859,164 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/core-darwin-arm64@npm:1.15.30":
+  version: 1.15.30
+  resolution: "@swc/core-darwin-arm64@npm:1.15.30"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@swc/core-darwin-x64@npm:1.15.30":
+  version: 1.15.30
+  resolution: "@swc/core-darwin-x64@npm:1.15.30"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-arm-gnueabihf@npm:1.15.30":
+  version: 1.15.30
+  resolution: "@swc/core-linux-arm-gnueabihf@npm:1.15.30"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-arm64-gnu@npm:1.15.30":
+  version: 1.15.30
+  resolution: "@swc/core-linux-arm64-gnu@npm:1.15.30"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-arm64-musl@npm:1.15.30":
+  version: 1.15.30
+  resolution: "@swc/core-linux-arm64-musl@npm:1.15.30"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-ppc64-gnu@npm:1.15.30":
+  version: 1.15.30
+  resolution: "@swc/core-linux-ppc64-gnu@npm:1.15.30"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-s390x-gnu@npm:1.15.30":
+  version: 1.15.30
+  resolution: "@swc/core-linux-s390x-gnu@npm:1.15.30"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-x64-gnu@npm:1.15.30":
+  version: 1.15.30
+  resolution: "@swc/core-linux-x64-gnu@npm:1.15.30"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-x64-musl@npm:1.15.30":
+  version: 1.15.30
+  resolution: "@swc/core-linux-x64-musl@npm:1.15.30"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@swc/core-win32-arm64-msvc@npm:1.15.30":
+  version: 1.15.30
+  resolution: "@swc/core-win32-arm64-msvc@npm:1.15.30"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@swc/core-win32-ia32-msvc@npm:1.15.30":
+  version: 1.15.30
+  resolution: "@swc/core-win32-ia32-msvc@npm:1.15.30"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@swc/core-win32-x64-msvc@npm:1.15.30":
+  version: 1.15.30
+  resolution: "@swc/core-win32-x64-msvc@npm:1.15.30"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@swc/core@npm:^1.15.2":
+  version: 1.15.30
+  resolution: "@swc/core@npm:1.15.30"
+  dependencies:
+    "@swc/core-darwin-arm64": "npm:1.15.30"
+    "@swc/core-darwin-x64": "npm:1.15.30"
+    "@swc/core-linux-arm-gnueabihf": "npm:1.15.30"
+    "@swc/core-linux-arm64-gnu": "npm:1.15.30"
+    "@swc/core-linux-arm64-musl": "npm:1.15.30"
+    "@swc/core-linux-ppc64-gnu": "npm:1.15.30"
+    "@swc/core-linux-s390x-gnu": "npm:1.15.30"
+    "@swc/core-linux-x64-gnu": "npm:1.15.30"
+    "@swc/core-linux-x64-musl": "npm:1.15.30"
+    "@swc/core-win32-arm64-msvc": "npm:1.15.30"
+    "@swc/core-win32-ia32-msvc": "npm:1.15.30"
+    "@swc/core-win32-x64-msvc": "npm:1.15.30"
+    "@swc/counter": "npm:^0.1.3"
+    "@swc/types": "npm:^0.1.26"
+  peerDependencies:
+    "@swc/helpers": ">=0.5.17"
+  dependenciesMeta:
+    "@swc/core-darwin-arm64":
+      optional: true
+    "@swc/core-darwin-x64":
+      optional: true
+    "@swc/core-linux-arm-gnueabihf":
+      optional: true
+    "@swc/core-linux-arm64-gnu":
+      optional: true
+    "@swc/core-linux-arm64-musl":
+      optional: true
+    "@swc/core-linux-ppc64-gnu":
+      optional: true
+    "@swc/core-linux-s390x-gnu":
+      optional: true
+    "@swc/core-linux-x64-gnu":
+      optional: true
+    "@swc/core-linux-x64-musl":
+      optional: true
+    "@swc/core-win32-arm64-msvc":
+      optional: true
+    "@swc/core-win32-ia32-msvc":
+      optional: true
+    "@swc/core-win32-x64-msvc":
+      optional: true
+  peerDependenciesMeta:
+    "@swc/helpers":
+      optional: true
+  checksum: 10/4b021a9203dcc2896c71dda267a9668c7b7edf8927292df7025f527374f4d05bb6fb29cde8472368aa8b35ae56ead1dc102eac1f1f2c7bb4bffcb184029146ea
+  languageName: node
+  linkType: hard
+
+"@swc/counter@npm:^0.1.3":
+  version: 0.1.3
+  resolution: "@swc/counter@npm:0.1.3"
+  checksum: 10/df8f9cfba9904d3d60f511664c70d23bb323b3a0803ec9890f60133954173047ba9bdeabce28cd70ba89ccd3fd6c71c7b0bd58be85f611e1ffbe5d5c18616598
+  languageName: node
+  linkType: hard
+
 "@swc/helpers@npm:0.5.15":
   version: 0.5.15
   resolution: "@swc/helpers@npm:0.5.15"
   dependencies:
     tslib: "npm:^2.8.0"
   checksum: 10/e3f32c6deeecfb0fa3f22edff03a7b358e7ce16d27b0f1c8b5cdc3042c5c4ce4da6eac0b781ab7cc4f54696ece657467d56734fb26883439fb00017385364c4c
+  languageName: node
+  linkType: hard
+
+"@swc/types@npm:^0.1.26":
+  version: 0.1.26
+  resolution: "@swc/types@npm:0.1.26"
+  dependencies:
+    "@swc/counter": "npm:^0.1.3"
+  checksum: 10/07de03b9da3928cdf69bda70bf2c809dd86f16ef23e357759e577bbd975529cb20218c2e54e72b00585abae2b5e04e39b8947cea7a6f4de2d40a7633be441919
   languageName: node
   linkType: hard
 
@@ -5562,6 +5753,7 @@ __metadata:
     meilisearch: "npm:^0.27.0"
     next: "npm:16.2.4"
     next-absolute-url: "npm:^1.2.2"
+    next-intl: "npm:^4.9.1"
     next-translate: "npm:3.1.2"
     next-translate-plugin: "npm:3.1.2"
     node-fetch: "npm:^3.2.10"
@@ -7032,6 +7224,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"icu-minify@npm:^4.9.1":
+  version: 4.9.1
+  resolution: "icu-minify@npm:4.9.1"
+  dependencies:
+    "@formatjs/icu-messageformat-parser": "npm:^3.4.0"
+  checksum: 10/121e532b15cfb943154070d1a046b52f181587fc6fef1a58fd2e1ee1d1c4a42f0f7c6c1a940c924c0c40c4b29e4abe1050dd94e7ba3902273010885e13543524
+  languageName: node
+  linkType: hard
+
 "ieee754@npm:^1.1.13, ieee754@npm:^1.2.1":
   version: 1.2.1
   resolution: "ieee754@npm:1.2.1"
@@ -7156,6 +7357,16 @@ __metadata:
     through: "npm:^2.3.6"
     wrap-ansi: "npm:^6.0.1"
   checksum: 10/f642b9e5a94faaba54f277bdda2af0e0a6b592bd7f88c60e1614b5795b19336c7025e0c2923915d5f494f600a02fe8517413779a794415bb79a9563b061d68ab
+  languageName: node
+  linkType: hard
+
+"intl-messageformat@npm:^11.1.0":
+  version: 11.2.1
+  resolution: "intl-messageformat@npm:11.2.1"
+  dependencies:
+    "@formatjs/fast-memoize": "npm:3.1.2"
+    "@formatjs/icu-messageformat-parser": "npm:3.5.4"
+  checksum: 10/ba32d3415676603d311f4b727f38cc8f7f597f24319e8a239bdfad3a0927e9ee52cfe53d96146fdb275ec593b8a6de8985720770e44132f971d4fe2242d51937
   languageName: node
   linkType: hard
 
@@ -8691,6 +8902,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"next-intl-swc-plugin-extractor@npm:^4.9.1":
+  version: 4.9.1
+  resolution: "next-intl-swc-plugin-extractor@npm:4.9.1"
+  checksum: 10/2339bf56037d5a6a87d9455aab40ff42be9b8b6dfade8d6b844c87a3b376e3b5a8b8775f8bf02ffb2fc812296098b145aa31b1cca50d85a971a1f800e839adc4
+  languageName: node
+  linkType: hard
+
+"next-intl@npm:^4.9.1":
+  version: 4.9.1
+  resolution: "next-intl@npm:4.9.1"
+  dependencies:
+    "@formatjs/intl-localematcher": "npm:^0.8.1"
+    "@parcel/watcher": "npm:^2.4.1"
+    "@swc/core": "npm:^1.15.2"
+    icu-minify: "npm:^4.9.1"
+    negotiator: "npm:^1.0.0"
+    next-intl-swc-plugin-extractor: "npm:^4.9.1"
+    po-parser: "npm:^2.1.1"
+    use-intl: "npm:^4.9.1"
+  peerDependencies:
+    next: ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10/66a2077b9f7321335f9f696732b3fb9d4c9c6a1245524a7fd78ae0e655b6e7a727ec83cf5c6a610942a5756d984a0fb97d482e76f3d876f84f4e086beb92e5c5
+  languageName: node
+  linkType: hard
+
 "next-translate-plugin@npm:3.1.2":
   version: 3.1.2
   resolution: "next-translate-plugin@npm:3.1.2"
@@ -9324,6 +9564,13 @@ __metadata:
   version: 4.0.6
   resolution: "pirates@npm:4.0.6"
   checksum: 10/d02dda76f4fec1cbdf395c36c11cf26f76a644f9f9a1bfa84d3167d0d3154d5289aacc72677aa20d599bb4a6937a471de1b65c995e2aea2d8687cbcd7e43ea5f
+  languageName: node
+  linkType: hard
+
+"po-parser@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "po-parser@npm:2.1.1"
+  checksum: 10/7bcf0055f4441256fd1cd2c09c4e2512207385f6a1a8952d9f7911ffccd0366720cfbd2be7aa11fb337f4b72c8a53866b8ba5a42da65f6ec19401df68bac8997
   languageName: node
   linkType: hard
 
@@ -11725,6 +11972,20 @@ __metadata:
   version: 8.0.2
   resolution: "urlpattern-polyfill@npm:8.0.2"
   checksum: 10/fd86b5c55473f3abbf9ed317b953c9cbb4fa6b3f75f681a1d982fe9c17bbc8d9bcf988f4cf3bda35e2e5875984086c97e177f97f076bb80dfa2beb85d1dd7b23
+  languageName: node
+  linkType: hard
+
+"use-intl@npm:^4.9.1":
+  version: 4.9.1
+  resolution: "use-intl@npm:4.9.1"
+  dependencies:
+    "@formatjs/fast-memoize": "npm:^3.1.0"
+    "@schummar/icu-type-parser": "npm:1.21.5"
+    icu-minify: "npm:^4.9.1"
+    intl-messageformat: "npm:^11.1.0"
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
+  checksum: 10/9734ebe88248858e9c438c17e5d32321869917060ab4f023c13d5f3d20c277e9cf3c5ef220764300060fea5f4fe4bfca7771690bdea8e3f131f0d463388c7008
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Phase 3a — App Router scaffolding + next-intl infra

Ports the shell for the App Router migration without moving any route off `pages/`. `pages/` still owns every URL; `app/[locale]/...` is ready but empty.

## Highlights

- **`next-intl` wired up** (`localePrefix: "as-needed"` — matches current URLs, Swedish unprefixed, English under `/en/...`).
- **App Router shell in place**: `app/layout.tsx` (passthrough) + `app/[locale]/layout.tsx` (RSC owns `<html lang>`, `<head>`, `/__ENV.js`).
- **CSP nonce bridge**: `proxy.ts` stamps per-request nonce on `x-nonce` (request + response); locale layout reads via `headers()` and falls back to a fresh nonce if missing.
- **Shared layout state** (`settingsOpen`, `openSideBar`, `imageHero`, `breadcrumbState`) moved out of `pages/_app.tsx` into a reusable `LayoutStateProvider` so it survives the move off `_app`.
- **Build passes on Turbopack** — fixed a Phase 2 fallout that was crashing `yarn build` (Winston pulled into the browser bundle).

## What changed

### New

- `i18n/routing.ts` — `defineRouting({ locales, defaultLocale, localePrefix: "as-needed", localeDetection: false })`.
- `i18n/request.ts` — `getRequestConfig`, preloads all 5 namespaces (`common`, `pages`, `resources`, `routes`, `filters`).
- `app/layout.tsx` — passthrough (locale layout below owns `<html>`).
- `app/[locale]/layout.tsx` — RSC, `generateStaticParams` per locale, injects `/__ENV.js` with nonce, wraps children in `AppRouterProviders`.
- `app/[locale]/not-found.tsx`, `app/[locale]/error.tsx`, `app/global-error.tsx` — minimal shells.
- `components/providers.tsx` — `AppRouterProviders` (`NextIntl → Settings → LocalStore → LayoutState → Matomo`).
- `providers/layout-state-provider/index.tsx` — shared layout chrome state, `useLayoutState()` hook.
- `utilities/layout-breadcrumb.ts` — single source for `initBreadcrumb`.

### Modified

- `proxy.ts` — replaced hand-rolled locale redirects with `createMiddleware(routing)` + CSP nonce.
- `next.config.mjs` — wrapped with `createNextIntlPlugin("./i18n/request.ts")`. Plugin order: `nextTranslate(withNextIntl(coreConfig), { turbopack: true })` (next-intl first so it doesn't see the legacy `i18n` key). Added `serverExternalPackages: ["winston", "@alfalab/winston3-logstash-transport"]`.
- `pages/_app.tsx` — split into outer `Dataportal` (renders `LayoutStateProvider`) + inner `DataportalChrome` (consumes the hook). Bridges `setBreadcrumb` into `SettingsContext` so the 14 pages still calling `setBreadcrumb?.({...})` keep working. Top-level `useRouter()` from `next/router` removed — hash effect now reads `props.router.asPath`.
- `pages/_error.tsx` — Winston logger moved behind a guarded dynamic import (`typeof window === "undefined"` + `webpackIgnore`/`turbopackIgnore` hints) to keep Node-only deps (`net`/`tls`/`fs`) out of the browser bundle.
- `package.json` — `+ next-intl@^4.9.1`.
- `docs/next15-app-router-migration.md` — Phase 3 marked 3a (done) / 3b (pending), pragmatic deviations documented.

### Drive-by fixes

- `pathname ?? ""` guards where `usePathname()` returning `string | null` now breaks the build under Next's regenerated `tsconfig.json`:
  - `components/blocks/fortroendemodellen-v2/index.tsx`
  - `components/form/form-generate-pdf/index.tsx`
  - `components/navigation/container-nav/index.tsx`
  - `components/navigation/main-nav/index.tsx`
  - `components/navigation/sidebar/sidebar-link/index.tsx`
  - `features/pages/form-page/index.tsx`

## Pragmatic deviations from the original plan

1. **`localePrefix: "as-needed"` (not `"always"`).** The plan said `"always"` "matches current `localeDetection: false` behavior" — that's wrong. The legacy proxy stripped `/sv/` and only prefixed English. Using `"always"` would force `/sv/datasets` everywhere and break every URL / bookmark / SEO signal.
2. **`next/router` → `next/navigation` sweep deferred.** Only `pages/_app.tsx` was migrated. The other ~38 callers all live inside Pages-Router-only files and will be ported alongside their page in Phase 4. Eager sweep would be a 38-file mechanical PR with no observable effect.
3. **i18n key flatten + `pathnames` split into Phase 3b.** The key flatten touches all 5 locale namespaces × 2 locales (~1200 lines of JSON) plus ~330 `t()` call sites in 64 files. Keeping Phase 3a tight unblocks Phase 4 without waiting on the codemod.
4. **Two-layout split.** `app/layout.tsx` is a passthrough and `app/[locale]/layout.tsx` owns `<html>`. Lets us render `<html lang={locale}>` dynamically — the documented `next-intl` pattern.

## Verification

- `yarn check-types` — pass
- `yarn biome check . --diagnostic-level=error` — pass
- `yarn build` — pass (Turbopack, all existing Pages routes prerender; `Proxy (Middleware)` shows in the route table)

## Still pending in Phase 3 (separate PR — "3b")

- [ ] Codemod locale JSON: `{"pages|startpage$heading": "..."}` → `{ "pages": { "startpage": { "heading": "..." } } }` across all 5 × 2 namespace files.
- [ ] Codemod `t("ns|key$sub")` → `t("ns.key.sub")` (or `useTranslations("ns")` + `t("key.sub")`) in all 64 callers.
- [ ] Generate `pathnames` map in `i18n/routing.ts` from `locales/{sv,en}/routes.json` so localized slugs (`/datasets` ↔ `/en/data-apis`) survive the App Router move.

## Test plan

- [ ] `yarn dev` — every current `pages/` route renders identically to `main` (spot-check start, `/en`, `/nyheter`, `/datasets`, `/stod-och-verktyg`, a fortroendemodellen subpage, 404).
- [ ] Locale switch: `/` stays on Swedish with no prefix; `/en` renders English. Direct visit to `/sv/...` redirects to unprefixed.
- [ ] CSP — no console errors, Matomo + `/__ENV.js` scripts ship with a matching nonce, no inline-script violations.
- [ ] Cookie banner → Matomo loader still fires on consent; `NEXT_PUBLIC_DISABLE_MATOMO=1` still disables it.
- [ ] Breadcrumbs still update on navigation (verifies the `setBreadcrumb` bridge from `LayoutStateProvider` into `SettingsContext`).
- [ ] `yarn build` + production smoke on the start page.