### PR TITLE
DIGG-628: add data-vocabulary page

### DIFF
--- a/src/app/[locale]/(entryscape)/_components/data-structures/data-structure-page/index.tsx
+++ b/src/app/[locale]/(entryscape)/_components/data-structures/data-structure-page/index.tsx
@@ -108,7 +108,7 @@ export function DataStructurePage({ pageType }: DataStructurePageProps) {
             size="sm"
             className="mb-sm font-strong text-textSecondary md:mb-md"
           >
-            {t("pages.data-structures.details")}
+            {t("common.details")}
           </Heading>
           <div className="space-y-lg">
             <div

--- a/src/app/[locale]/(entryscape)/_components/data-structures/data-vocabulary-page/index.tsx
+++ b/src/app/[locale]/(entryscape)/_components/data-structures/data-vocabulary-page/index.tsx
@@ -17,17 +17,22 @@ import { buildFacetSearchLink } from "@/lib/entrystore/entrystore-helpers";
 import { EntrystoreContext } from "@/lib/entrystore/provider";
 import { buildBreadcrumb } from "@/utilities/breadcrumb-helpers";
 
-export function TerminologyPage() {
+export function DataVocabularyPage() {
   const entry = useContext(EntrystoreContext);
   const t = useTranslations();
 
-  const viewAllHref = buildFacetSearchLink(
-    t("routes.data-structures.path"),
-    "http://www.w3.org/2004/02/skos/core#inScheme",
-    entry.address,
-    t("pages.terminology.terminology"),
-    entry.title,
-  );
+  // Classes/properties reference their data vocabulary via rdfs:isDefinedBy.
+  // The "view all" link filters the data-structures search to this vocabulary
+  // and, per list, to only classes / only properties.
+  const buildViewAllHref = (rdfType: "term_class" | "term_property") =>
+    buildFacetSearchLink(
+      t("routes.data-structures.path"),
+      "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+      entry.address,
+      t("pages.data-vocabulary.data-vocabulary"),
+      entry.title,
+      rdfType,
+    );
 
   return (
     <EntryscapeResourcePage
@@ -50,7 +55,7 @@ export function TerminologyPage() {
             className="mb-xl"
           />
           <Badge
-            text={t("pages.terminology.terminology")}
+            text={t("pages.data-vocabulary.data-vocabulary")}
             color="dark-green"
             className="flex w-fit"
           />
@@ -60,18 +65,28 @@ export function TerminologyPage() {
         <>
           <p
             data-entryscape="text"
-            data-entryscape-property="dcterms:description"
+            data-entryscape-property="rdfs:comment"
             className="mb-lg empty:mb-none text-textSecondary whitespace-pre-line"
           />
 
           <MembersAccordion
-            relationinverse="skos:inScheme"
-            rdftype="skos:Concept"
-            rowLink="{{conceptLink}}"
-            countPrefixKey="pages.terminology.includes"
-            unitKey="concepts"
-            viewAllKey="pages.terminology.view_all"
-            viewAllHref={viewAllHref}
+            relationinverse="rdfs:isDefinedBy"
+            rdftype="rdfs:Class"
+            rowLink={'{{link namedclick="class"}}'}
+            countPrefixKey="pages.data-vocabulary.includes"
+            unitKey="classes"
+            viewAllKey="pages.data-vocabulary.view_all_classes"
+            viewAllHref={buildViewAllHref("term_class")}
+          />
+          <MembersAccordion
+            relationinverse="rdfs:isDefinedBy"
+            rdftype="rdf:Property"
+            rowLink={'{{link namedclick="property"}}'}
+            countPrefixKey="pages.data-vocabulary.includes"
+            unitKey="properties"
+            viewAllKey="pages.data-vocabulary.view_all_properties"
+            viewAllHref={buildViewAllHref("term_property")}
+            className="mt-lg"
           />
 
           <InteroperableSpecificationsAccordion />
@@ -83,14 +98,14 @@ export function TerminologyPage() {
             <Heading
               level={2}
               size="sm"
-              className="mb-sm font-strong text-textSecondary md:mb-md"
+              className="mb-sm text-textSecondary md:mb-md"
             >
               {t("common.details")}
             </Heading>
             <div className="space-y-lg">
               <SidebarSection
                 testId="address"
-                heading={t("pages.terminology.address")}
+                heading={t("pages.data-vocabulary.address")}
                 items={[{ title: entry.address, url: entry.address }]}
               />
 
@@ -107,7 +122,7 @@ export function TerminologyPage() {
               />
             </div>
           </Box>
-          <InteroperableSpecificationsCard labelKey="pages.terminology.specifications_use" />
+          <InteroperableSpecificationsCard labelKey="pages.data-vocabulary.specifications_use" />
         </>
       }
     />

--- a/src/app/[locale]/(entryscape)/_components/data-structures/interoperable-specifications.tsx
+++ b/src/app/[locale]/(entryscape)/_components/data-structures/interoperable-specifications.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useContext } from "react";
+import ListBlockIcon from "@/assets/icons/list-block.svg";
+import { Accordion } from "@/components/accordion";
+import { Box } from "@/components/box";
+import { LabelLink } from "@/components/label-link";
+import { EntrystoreContext } from "@/lib/entrystore/provider";
+import { SettingsContext } from "@/providers/settings-provider";
+
+/**
+ * Main-column accordion listing the interoperable specifications that use this
+ * terminology / data vocabulary. Renders nothing when there are none. Shared by
+ * the terminology and data-vocabulary pages.
+ */
+export function InteroperableSpecificationsAccordion() {
+  const entry = useContext(EntrystoreContext);
+  const t = useTranslations();
+  const specs = entry.relatedSpecificationsInteroperable;
+
+  if (!specs?.length) return null;
+
+  return (
+    <Accordion
+      testId="used-in-specifications"
+      title={
+        <span>
+          {t("common.used-in")}{" "}
+          <span className="font-strong">
+            {specs.length} {t("common.interoperable-specifications")}
+          </span>
+        </span>
+      }
+      className="mt-lg"
+    >
+      <ul className="space-y-sm">
+        {specs.map((spec) => (
+          <li key={spec.url}>
+            <Box color="white">
+              <LabelLink
+                value={spec}
+                size="medium"
+                color="primary"
+                underline={false}
+              />
+            </Box>
+          </li>
+        ))}
+      </ul>
+    </Accordion>
+  );
+}
+
+interface InteroperableSpecificationsCardProps {
+  /** i18n key for the "… use this X" label (terminology vs data vocabulary). */
+  labelKey:
+    | "pages.terminology.specifications_use"
+    | "pages.data-vocabulary.specifications_use";
+}
+
+/**
+ * Sidebar count card: "N interoperable specifications use this terminology /
+ * data vocabulary". Shared by the terminology and data-vocabulary pages.
+ */
+export function InteroperableSpecificationsCard({
+  labelKey,
+}: InteroperableSpecificationsCardProps) {
+  const entry = useContext(EntrystoreContext);
+  const { iconSize } = useContext(SettingsContext);
+  const t = useTranslations();
+
+  return (
+    <Box color="white" padding="xl" rounded={true}>
+      <div className="flex items-center gap-sm">
+        <ListBlockIcon
+          className="flex-shrink-0 text-primary"
+          height={iconSize * 3}
+          width={iconSize * 3}
+          viewBox={`0 0 ${iconSize * 1.5} ${iconSize * 1.5}`}
+        />
+
+        <span className="text-xl md:text-2xl text-primary">
+          {entry.relatedSpecificationsInteroperable?.length}
+        </span>
+        <span className="text-sm leading-4">{t(labelKey)}</span>
+      </div>
+    </Box>
+  );
+}

--- a/src/app/[locale]/(entryscape)/_components/data-structures/members-accordion.tsx
+++ b/src/app/[locale]/(entryscape)/_components/data-structures/members-accordion.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import ArrowRightIcon from "@/assets/icons/arrow-right.svg";
+import { Accordion } from "@/components/accordion";
+import { Box } from "@/components/box";
+import { ButtonLink } from "@/components/button";
+
+interface MembersAccordionProps {
+  /** Inverse relation from a member back to this scheme/vocabulary. */
+  relationinverse: string;
+  /** rdf:type of the members to list. */
+  rdftype: string;
+  /**
+   * Handlebars snippet rendering one member row's link. Concepts use the
+   * `conceptLink` block (pretty in-store path); classes/properties have no
+   * vanity path, so a plain `{{link}}` on a config named-click route suffices.
+   */
+  rowLink: string;
+  /** Full i18n key for the count prefix ("I terminologin ingår" …). */
+  countPrefixKey:
+    | "pages.terminology.includes"
+    | "pages.data-vocabulary.includes";
+  /** concepts key for the plural unit (begrepp / klasser / egenskaper). */
+  unitKey: "concepts" | "classes" | "properties";
+  /** Full i18n key for the "view all" button label. */
+  viewAllKey:
+    | "pages.terminology.view_all"
+    | "pages.data-vocabulary.view_all_classes"
+    | "pages.data-vocabulary.view_all_properties";
+  viewAllHref: string;
+  className?: string;
+}
+
+/**
+ * One count-titled accordion listing a scheme's/vocabulary's members (concepts,
+ * classes or properties). Hidden when empty; a standalone placeholder then
+ * renders the same "0 …" count title in its place. Shared by the terminology
+ * and data-vocabulary pages.
+ */
+export function MembersAccordion({
+  relationinverse,
+  rdftype,
+  rowLink,
+  countPrefixKey,
+  unitKey,
+  viewAllKey,
+  viewAllHref,
+  className,
+}: MembersAccordionProps) {
+  const t = useTranslations();
+  const prefix = t(countPrefixKey);
+  const unit = t(`pages.concepts.${unitKey}`);
+
+  return (
+    <div className={className}>
+      {/* Shown only when there are 0 members (the accordion is hidden then). */}
+      <span
+        className="block text-lg"
+        data-entryscape="listStandard"
+        data-entryscape-relationinverse={relationinverse}
+        data-entryscape-rdftype={rdftype}
+        data-entryscape-limit="1"
+        data-entryscape-listbody="<span class='hidden'>{{body}}</span>"
+        data-entryscape-listplaceholder={`${prefix} <span class="font-strong">0 ${unit}</span>`}
+      />
+
+      <Accordion
+        testId={`members-${unitKey}`}
+        className="[&:not(:has(.member-row))]:hidden"
+        title={
+          <span
+            data-entryscape="listStandard"
+            data-entryscape-relationinverse={relationinverse}
+            data-entryscape-rdftype={rdftype}
+            data-entryscape-limit="1"
+            data-entryscape-listbody="<span class='hidden'>{{body}}</span>"
+            data-entryscape-listhead={`${prefix} <span class="font-strong">{{resultsize}} ${unit}</span>`}
+          />
+        }
+      >
+        <Box color="green">
+          <div
+            className="[&_.entryPagination]:hidden [&_ul]:flex [&_ul]:flex-wrap [&_ul]:gap-y-sm [&_ul]:gap-x-md"
+            data-entryscape="listStandard"
+            data-entryscape-relationinverse={relationinverse}
+            data-entryscape-rdftype={rdftype}
+            data-entryscape-limit="4"
+            data-entryscape-listbody="{{body}}"
+            data-entryscape-rowhead={`<span class='member-row'>${rowLink}</span>`}
+          />
+          <ButtonLink
+            href={viewAllHref}
+            label={t(viewAllKey)}
+            icon={ArrowRightIcon}
+            iconPosition="right"
+          />
+        </Box>
+      </Accordion>
+    </div>
+  );
+}

--- a/src/app/[locale]/(entryscape)/data-vocabulary/[data]/page.tsx
+++ b/src/app/[locale]/(entryscape)/data-vocabulary/[data]/page.tsx
@@ -1,0 +1,17 @@
+import { DataVocabularyPage } from "@/app/[locale]/(entryscape)/_components/data-structures/data-vocabulary-page";
+import { renderEntryStoreResourcePage } from "@/app/[locale]/(entryscape)/_server/render-resource-page";
+
+interface PageProps {
+  params: Promise<{ locale: string; data: string }>;
+}
+
+export default async function DataVocabulary({ params }: PageProps) {
+  const { locale, data } = await params;
+
+  return renderEntryStoreResourcePage({
+    locale,
+    pageType: "data-vocabulary",
+    param: data,
+    body: <DataVocabularyPage />,
+  });
+}

--- a/src/app/[locale]/(entryscape)/layout.tsx
+++ b/src/app/[locale]/(entryscape)/layout.tsx
@@ -1,30 +1,18 @@
 import type { ReactNode } from "react";
 
-import { getEntryscapeEnv } from "@/lib/entrystore/route-helpers";
 import "@/styles/entryscape.css";
 import "@/styles/entryscape-mqa.css";
 
 /**
- * Preconnect/preload the EntryStore origins and blocks scripts here (not the
- * locale layout) so CMS-only pages don't pay for it, and so the block scripts
- * start downloading during the initial HTML stream rather than after mount.
- * Entryscape/MQA CSS is imported here for the same reason.
+ * Preconnect to the EntryStore / blocks origins so store fetches (search and
+ * resource pages) start early. The block-script `preload` lives in
+ * EntrystoreProvider so only resource pages request it — search pages don't.
  */
-export default async function EntryscapeLayout({
+export default function EntryscapeLayout({
   children,
 }: {
   children: ReactNode;
 }) {
-  const { env } = await getEntryscapeEnv();
-
-  // Same list as ensureLib() in use-blocks.ts (tmp bundle host hardcoded there).
-  const blockScripts = [
-    "https://sandbox.admin.dataportal.se/tmp/blocks.js",
-    env.ENTRYSCAPE_OPENDATA_URL,
-    env.ENTRYSCAPE_MQA_URL,
-    env.ENTRYSCAPE_BLOCKS_URL,
-  ];
-
   return (
     <>
       <link
@@ -41,9 +29,6 @@ export default async function EntryscapeLayout({
       <link rel="preconnect" href="https://static.cdn.entryscape.com" />
       <link rel="preconnect" href="https://static.entryscape.com" />
       <link rel="preconnect" href="https://sandbox.admin.dataportal.se" />
-      {blockScripts.map((href) => (
-        <link key={href} rel="preload" as="script" href={href} />
-      ))}
       {children}
     </>
   );

--- a/src/lib/entryscape-blocks/config.ts
+++ b/src/lib/entryscape-blocks/config.ts
@@ -34,6 +34,8 @@ export const createBlocksConfig = ({
     ...(esId !== "" && { entry: esId }),
     clicks: {
       concept: `${includeLangInPath(lang)}/concepts/\${context}_\${entry}`,
+      class: `${includeLangInPath(lang)}/class/\${context}_\${entry}`,
+      property: `${includeLangInPath(lang)}/property/\${context}_\${entry}`,
       "dataservice-link": `${includeLangInPath(lang)}/dataservice/\${context}_\${entry}`,
       katalog: `${includeLangInPath(lang)}/metadatakvalitet/katalog/\${entry}/\${context}`,
     },

--- a/src/lib/entryscape-blocks/use-blocks.ts
+++ b/src/lib/entryscape-blocks/use-blocks.ts
@@ -47,6 +47,14 @@ const loadScript = (url: string): Promise<void> =>
     container.appendChild(script);
   });
 
+/** Ordered block-engine scripts, shared by ensureLib (loads) + provider (preloads). */
+export const blockScriptUrls = (env: EnvSettings): string[] => [
+  "https://sandbox.admin.dataportal.se/tmp/blocks.js",
+  env.ENTRYSCAPE_OPENDATA_URL,
+  env.ENTRYSCAPE_MQA_URL,
+  env.ENTRYSCAPE_BLOCKS_URL,
+];
+
 const ensureLib = (env: EnvSettings): Promise<void> => {
   if (libPromise) return libPromise;
   libPromise = (async () => {
@@ -58,10 +66,7 @@ const ensureLib = (env: EnvSettings): Promise<void> => {
     // They register the base blocks (e.g. catalogMQA) and RDForms bundles that
     // the pages rely on; addConfig()/setEntryStore()/init() come from the engine
     // itself (ENTRYSCAPE_BLOCKS_URL), so no extra bundle is needed.
-    await loadScript("https://sandbox.admin.dataportal.se/tmp/blocks.js");
-    await loadScript(env.ENTRYSCAPE_OPENDATA_URL);
-    await loadScript(env.ENTRYSCAPE_MQA_URL);
-    await loadScript(env.ENTRYSCAPE_BLOCKS_URL);
+    for (const url of blockScriptUrls(env)) await loadScript(url);
     await window.__entryscape_blocks_ready;
   })();
   return libPromise;

--- a/src/lib/entrystore/entrystore-core.ts
+++ b/src/lib/entrystore/entrystore-core.ts
@@ -54,6 +54,7 @@ export type PageType =
   | "apiexplore"
   | "organisation"
   | "terminology"
+  | "data-vocabulary"
   | "specification"
   | "concept"
   | "class"
@@ -71,13 +72,14 @@ export type RedirectPath =
   | "/class"
   | "/property";
 
-/** Page types that resolve a resource URI into a canonical redirect. */
+/** Page types routed through the resolver (existence check + optional redirect). */
 export type ResolverPageType =
   | "specification"
   | "terminology"
   | "concept"
   | "class"
-  | "property";
+  | "property"
+  | "data-vocabulary";
 
 /**
  * Per-page routing config. `store` is required for every page; `pathPrefix`
@@ -106,6 +108,7 @@ export const ROUTE_CONFIG = {
     pathPrefix: "/specifications",
     redirectPath: "/specifications",
   },
+  "data-vocabulary": { store: "admin" },
   terminology: {
     store: "editera",
     pathPrefix: "/concepts",
@@ -116,12 +119,8 @@ export const ROUTE_CONFIG = {
     pathPrefix: "/concepts",
     redirectPath: "/concepts",
   },
-  class: { store: "editera", pathPrefix: "/concepts", redirectPath: "/class" },
-  property: {
-    store: "editera",
-    pathPrefix: "/concepts",
-    redirectPath: "/property",
-  },
+  class: { store: "editera", redirectPath: "/class" },
+  property: { store: "editera", redirectPath: "/property" },
 } as const satisfies Record<PageType, RouteConfig>;
 
 /** A label that is optionally a link (url absent/empty ⇒ render as text). */

--- a/src/lib/entrystore/entrystore-helpers.ts
+++ b/src/lib/entrystore/entrystore-helpers.ts
@@ -161,16 +161,22 @@ export function formatTerminologyAddress(
     : resourceUri;
 }
 
-/** Search URL with one URI facet pre-selected (the `f=` facet-value format). */
+/**
+ * Search URL with one URI facet pre-selected (the `f=` facet-value format).
+ * `rdfType` optionally restricts the result type via `rt=` (an `ESRdfType`
+ * key, e.g. `term_class` / `term_property`).
+ */
 export function buildFacetSearchLink(
   path: string,
   predicate: string,
   resource: string,
   facetLabel: string,
   title: string,
+  rdfType?: string,
 ): string {
   const facetValue = `${predicate}||${resource}||false||uri||${facetLabel}||${title}`;
-  return `/${path}?q=&f=${encodeURIComponent(facetValue)}`;
+  const rt = rdfType ? `&rt=${rdfType}` : "";
+  return `/${path}?q=&f=${encodeURIComponent(facetValue)}${rt}`;
 }
 
 /** Base URL of a page's chosen store, resolved against the given env. */

--- a/src/lib/entrystore/entrystore.service.ts
+++ b/src/lib/entrystore/entrystore.service.ts
@@ -1015,7 +1015,11 @@ export class EntrystoreService {
             })),
           interoperable: [] as LabelLink[],
         };
-      } else if (pageType === "terminology" || pageType === "concept") {
+      } else if (
+        pageType === "terminology" ||
+        pageType === "concept" ||
+        pageType === "data-vocabulary"
+      ) {
         const resourceUri = entry
           .getResourceURI()
           .replace(
@@ -1072,13 +1076,12 @@ export class EntrystoreService {
    */
   public async getDataVocabularyLink(
     metadata: Metadata,
-    adminService: EntrystoreService = this,
   ): Promise<LabelLink | undefined> {
     const uri = metadata.findFirstValue(null, "rdfs:isDefinedBy");
     if (!uri) return undefined;
 
     try {
-      const ref = await adminService.getEntryByResourceURI(uri);
+      const ref = await this.getEntryByResourceURI(uri);
 
       const refMeta = ref.getAllMetadata();
       const label =

--- a/src/lib/entrystore/provider/index.tsx
+++ b/src/lib/entrystore/provider/index.tsx
@@ -13,7 +13,10 @@ import {
 import type { EnvSettings } from "@/env";
 import { SettingsUtil } from "@/env/settings-util";
 import { useResourceLabel } from "@/i18n/use-resource-label";
-import { useEntryScapeBlocks } from "@/lib/entryscape-blocks/use-blocks";
+import {
+  blockScriptUrls,
+  useEntryScapeBlocks,
+} from "@/lib/entryscape-blocks/use-blocks";
 import { EntrystoreService } from "@/lib/entrystore/entrystore.service";
 import {
   type EntryStoreName,
@@ -189,6 +192,7 @@ export const EntrystoreProvider: FC<EntrystoreProviderProps> = ({
         description: getFirstMatchingValue(metadata, resourceUri, [
           "skos:definition",
           "dcterms:description",
+          "rdfs:comment",
         ]),
         address: resourceUri,
         loading: false,
@@ -325,7 +329,8 @@ export const EntrystoreProvider: FC<EntrystoreProviderProps> = ({
         };
       }
 
-      case "terminology": {
+      case "terminology":
+      case "data-vocabulary": {
         // Fetch specifications and formats in parallel. Specs live in the
         // admin store.
         const [specs, formats, organisationLink] = await Promise.all([
@@ -338,6 +343,7 @@ export const EntrystoreProvider: FC<EntrystoreProviderProps> = ({
 
         return {
           relatedSpecifications: specs.all,
+          relatedSpecificationsInteroperable: specs.interoperable,
           address: formatTerminologyAddress(resourceUri, [
             env.PRODUCTION_BASE_URL,
             env.SANDBOX_BASE_URL,
@@ -408,7 +414,7 @@ export const EntrystoreProvider: FC<EntrystoreProviderProps> = ({
       case "property": {
         // Fetch data structure details and formats in parallel
         const [definedBy, formats] = await Promise.all([
-          entrystoreService.getDataVocabularyLink(metadata, stores.admin),
+          stores.admin.getDataVocabularyLink(metadata),
           entrystoreService.getDownloadFormats(
             entry.getEntryInfo().getMetadataURI(),
           ),
@@ -633,10 +639,17 @@ export const EntrystoreProvider: FC<EntrystoreProviderProps> = ({
     }
   };
 
-  if (state.loading) return null;
+  // Block-script preload lives here (not the layout) so only resource pages
+  // request it — search pages would preload-but-never-use it.
+  const blockScriptPreloads = blockScriptUrls(env).map((href) => (
+    <link key={href} rel="preload" as="script" href={href} />
+  ));
+
+  if (state.loading) return <>{blockScriptPreloads}</>;
 
   return (
     <EntrystoreContext.Provider value={state}>
+      {blockScriptPreloads}
       <title>{`${state.title} - Sveriges dataportal`}</title>
       <meta
         property="og:title"

--- a/src/lib/entrystore/resolve-entry-store-route.ts
+++ b/src/lib/entrystore/resolve-entry-store-route.ts
@@ -64,10 +64,11 @@ export async function resolveEntryStoreRoute(
         const entry = await entrystoreService.getEntry(cid, eid);
         const entryResourceUri = entry.getResourceURI();
 
-        if (entryResourceUri.startsWith(baseUrl)) {
+        // Only redirect in-store URIs; external-URI pages render directly.
+        if (config.redirectPath && entryResourceUri.startsWith(baseUrl)) {
           return {
             type: "redirect",
-            url: `${includeLangInPath(locale)}${config.redirectPath}${entryResourceUri.replace(`${baseUrl}${config.pathPrefix}`, "")}`,
+            url: `${includeLangInPath(locale)}${config.redirectPath}${entryResourceUri.replace(`${baseUrl}${config.pathPrefix ?? ""}`, "")}`,
           };
         }
         return { type: "entry", cid, eid };
@@ -76,7 +77,9 @@ export async function resolveEntryStoreRoute(
       }
     }
 
-    // Construct resourceUri from param(s)
+    // A resourceUri can only be built when the page declares a pathPrefix.
+    if (!config.pathPrefix) return { type: "notFound" };
+
     const pathSuffix = config.secondParam
       ? `${param}/${config.secondParam}`
       : param;
@@ -93,7 +96,7 @@ export async function resolveEntryStoreRoute(
       resourceUri || "",
     );
 
-    if (entry) {
+    if (entry && config.redirectPath) {
       return {
         type: "redirect",
         url: `${includeLangInPath(locale)}${config.redirectPath}/${entry.getContext().getId()}_${entry.getId()}`,

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -14,9 +14,9 @@
   "clear-filters": "Clear filters",
   "clear-search": "Clear search field",
   "close": "Close",
-  "close-filter": "Close filter",
   "close_menu": "Menu",
   "close_search": "Search",
+  "close-filter": "Close filter",
   "code-block": "Code block",
   "code-copied-successfully": "Code copied successfully",
   "code-copy-failed": "Failed to copy code",
@@ -32,6 +32,7 @@
   "datasets": "Datasets",
   "datastructures": "Datastructures",
   "description": "Description",
+  "details": "Details",
   "digg-logo_text": "DIGG - Agency for digital government",
   "digg-managed_text": "DIGG is managed by the Swedish Agency for Digital Government",
   "documentation-services": "Documentation och services - Sweden's dataportal",
@@ -54,6 +55,7 @@
   "illustration-1": "Illustration av kommunikation mellan dator och mobil",
   "illustration-2": "Illustration av ett hus",
   "illustration-3": "Illustration av dator som tar emot data",
+  "interoperable-specifications": "interoperable specifications",
   "lang-linktext": "Svenska",
   "load-more": "Load more",
   "loading": "Loading",
@@ -110,5 +112,6 @@
   "toolbox-share-data": "Toolbox for sharing data",
   "top-image": "View of Stockholm",
   "training": "Training for managers and leaders",
+  "used-in": "Used in",
   "yes": "Yes"
 }

--- a/src/locales/en/pages.json
+++ b/src/locales/en/pages.json
@@ -7,7 +7,6 @@
   },
   "concept_page": {
     "about_concept": "About concept",
-    "about_terminology": "About terminology",
     "alternativ_term": "Alternative term",
     "close_match": "Has close match",
     "concept_adress": "Address for concept",
@@ -30,12 +29,13 @@
     "subordinate_match": "Has subordinate match",
     "superior_concept": "Superior concept",
     "superior_match": "Has superior match",
-    "term_adress": "Address for terminology",
     "terminology_concept": "Terminology",
     "visualization_concepts": "Visualization of subordinate concepts"
   },
   "concepts": {
+    "classes": "classes",
     "concepts": "concepts",
+    "properties": "properties",
     "search": "Search",
     "social_meta_description": "Concepts on Sweden's data portal",
     "social_meta_title": "Search concepts"
@@ -53,7 +53,6 @@
   },
   "data-structures": {
     "data-vocabulary": "Data vocabulary",
-    "details": "Details",
     "introduced-in-specification": "Introduced in specification",
     "no-introduced-in-specification": "Not introduced in any specification",
     "no-reused-in-specification": "Not reused in any specification",
@@ -65,6 +64,14 @@
       "concept": "Concept",
       "property": "Property"
     }
+  },
+  "data-vocabulary": {
+    "address": "Address for data vocabulary",
+    "data-vocabulary": "Data vocabulary",
+    "includes": "The data vocabulary includes",
+    "specifications_use": "Interoperable specifications use this data vocabulary",
+    "view_all_classes": "View all classes",
+    "view_all_properties": "View all properties"
   },
   "dataservicepage": {
     "api": "About API"
@@ -96,7 +103,7 @@
     "rdf": "Download metadata as RDF",
     "read_about_api": "Read more about API",
     "related_dataset_series": "Belongs to dataset serie: ",
-    "related_specifications": "Specification",
+    "related_specifications": "Specifications",
     "several_links": "The data has several links for download",
     "several_links_header": "The data resource consists of the following files",
     "use-data": "Use data",
@@ -325,5 +332,12 @@
     "statistic-page-text": "Statistics visualized on the startpage is here available in text. The statistics shows the amount of data on Sweden´s dataportal per month, top 5 organisations and categories.",
     "top-categories": "Categories with the most datasets",
     "top-organisations": "Organisations with the most datasets"
+  },
+  "terminology": {
+    "address": "Address for terminology",
+    "includes": "The terminology includes",
+    "specifications_use": "Interoperable specifications use this terminology",
+    "terminology": "Terminology",
+    "view_all": "View all concepts"
   }
 }

--- a/src/locales/sv/common.json
+++ b/src/locales/sv/common.json
@@ -15,9 +15,9 @@
   "clear-filters": "Rensa filter",
   "clear-search": "Rensa sökfält",
   "close": "Stäng",
-  "close-filter": "Stäng filter",
   "close_menu": "Meny",
   "close_search": "Sök",
+  "close-filter": "Stäng filter",
   "code-block": "Kodblock",
   "code-copied-successfully": "Kod kopierad",
   "code-copy-failed": "Misslyckades med kodkopiering",
@@ -32,6 +32,7 @@
   "datasets": "Datamängder",
   "datastructures": "Datastrukturer",
   "description": "Beskrivning",
+  "details": "Detaljer",
   "digg-logo_text": "DIGG - Myndigheten för digital förvaltning",
   "digg-managed_text": "Webbplatsen förvaltas av DIGG – Myndigheten för digital förvaltning",
   "documentation-services": "Dokumentation och tjänster - Sveriges dataportal",
@@ -54,6 +55,7 @@
   "illustration-1": "Illustration av kommunikation mellan dator och mobil",
   "illustration-2": "Illustration av ett hus",
   "illustration-3": "Illustration av dator som tar emot data",
+  "interoperable-specifications": "interoperabla specifikationer",
   "lang-linktext": "English",
   "load-more": "Ladda fler",
   "loading": "Laddar...",
@@ -110,5 +112,6 @@
   "toolbox-share-data": "Verktygslåda för att dela data",
   "top-image": "Vy över Stockholm",
   "training": "Utbildning för chefer och ledare",
+  "used-in": "Används i",
   "yes": "Ja"
 }

--- a/src/locales/sv/pages.json
+++ b/src/locales/sv/pages.json
@@ -8,7 +8,6 @@
   },
   "concept_page": {
     "about_concept": "Om begrepp",
-    "about_terminology": "Om terminologi",
     "alternativ_term": "Alternativ term",
     "close_match": "Har snarlikt motsvarande begrepp ",
     "concept_adress": "Adress för begrepp",
@@ -31,12 +30,13 @@
     "subordinate_match": "Har underordnat motsvarande begrepp",
     "superior_concept": "Överordnade begrepp",
     "superior_match": "Har överordnat motsvarande begrepp",
-    "term_adress": "Adress för terminologi",
     "terminology_concept": "Terminologi",
     "visualization_concepts": "Visualisering av underordnade begrepp"
   },
   "concepts": {
+    "classes": "klasser",
     "concepts": "begrepp",
+    "properties": "egenskaper",
     "search": "Sök begrepp",
     "social_meta_description": "Begrepp på Sveriges Dataportal",
     "social_meta_title": "Sök begrepp"
@@ -53,7 +53,6 @@
   },
   "data-structures": {
     "data-vocabulary": "Datavokabulär",
-    "details": "Detaljer",
     "introduced-in-specification": "Introduceras i specifikation",
     "no-introduced-in-specification": "Introduceras inte i någon specifikation",
     "no-reused-in-specification": "Återanvänds inte i någon specifikation",
@@ -65,6 +64,14 @@
       "concept": "Begrepp",
       "property": "Egenskap"
     }
+  },
+  "data-vocabulary": {
+    "address": "Adress för datavokabulär",
+    "data-vocabulary": "Datavokabulär",
+    "includes": "I datavokabuläret ingår",
+    "specifications_use": "Interoperabla specifikationer använder detta datavokabulär",
+    "view_all_classes": "Visa alla klasser",
+    "view_all_properties": "Visa alla egenskaper"
   },
   "dataservicepage": {
     "api": "Om API"
@@ -96,7 +103,7 @@
     "rdf": "Ladda ner metadata som RDF",
     "read_about_api": "Läs mer om API",
     "related_dataset_series": "Tillhör datamängdsserie: ",
-    "related_specifications": "Specifikation",
+    "related_specifications": "Specifikationer",
     "several_links": "Datat har flertalet länkar för nedladdning",
     "several_links_header": "Dataresursen består av följande filer",
     "use-data": "Använd data",
@@ -332,5 +339,12 @@
     "statistic-page-text": "Statistiken som visualiseras på startsidan presenteras här i textform.  Statistiken visar mängden data på Sveriges Dataportal per månad, topp 5 gällande datamängder för organisationer och kategorier.",
     "top-categories": "Kategorier med flest datamängder",
     "top-organisations": "Organisationer med flest datamängder"
+  },
+  "terminology": {
+    "address": "Adress för terminologi",
+    "includes": "I terminologin ingår",
+    "specifications_use": "Interoperabla specifikationer använder denna terminologi",
+    "terminology": "Terminologi",
+    "view_all": "Visa alla begrepp"
   }
 }

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -91,8 +91,8 @@ export interface DataportalSettings {
 }
 
 export type RedirectConfig = {
-  pathPrefix: string;
-  redirectPath:
+  pathPrefix?: string;
+  redirectPath?:
     | "/concepts"
     | "/specifications"
     | "/terminology"


### PR DESCRIPTION
Landing page for data vocabularies (owl:Ontology) at /data-vocabulary/{ctx}_{id}: class/property member lists, the interoperable-specifications accordion + count card, and a Detaljer sidebar.

- Share MembersAccordion + InteroperableSpecifications between the terminology and data-vocabulary pages.
- Make resolveEntryStoreRoute's pathPrefix/redirectPath optional so external-URI pages get a server-side notFound() with no redirect config; drop dead pathPrefix from class/property.
- Reorganize concept_page translations into terminology/data-vocabulary sections; move shared labels to common.
- Scope entryscape block-script preload to resource pages via the provider (fixes "preloaded but unused" warnings on search pages); single-source the script list.
- buildFacetSearchLink gains an rt= type filter for class/property view-all.