### PR TITLE
fix(search): åtgärda sidnumrering i paginering vid återgång till sida 1

### DIFF
--- a/cypress/e2e/search/search-datasets.cy.ts
+++ b/cypress/e2e/search/search-datasets.cy.ts
@@ -67,4 +67,64 @@ describe("Search datasets", () => {
 
     cy.get("@filterToggle").should("have.attr", "aria-expanded", "false");
   });
+
+  /**
+   * Verify that the active page marking in the pagination follows the user
+   * back to page 1.
+   *
+   * Regression test: `search.request.page` is 0-indexed, so page 1 is stored as
+   * 0. The previous logic (`search?.request.page && search?.request.page + 1`)
+   * short-circuited on the falsy 0 and passed 0 to <Pagination />, where a
+   * second falsy guard kept the active marking stuck on "2".
+   */
+  it("Verify pagination active page marking returns to page 1", () => {
+    // Search for a term that yields enough hits to render more than one page.
+    cy.get("[data-test-id='search-input']").find("input").type(SEARCH_INPUT);
+    cy.get("[data-test-id='search-button']").click();
+
+    // Wait for the search results to finish loading.
+    cy.get("[data-test-id='search-button']", { timeout: 10000 }).should(
+      "have.attr",
+      "data-test-loading",
+      "false",
+    );
+
+    cy.get("[data-test-id='pagination']").should("be.visible");
+
+    // Page 1 is the active page when the search results are first rendered.
+    cy.get("[data-test-id='pagination']")
+      .find('button[aria-label="sida 1"]')
+      .should("have.class", "bg-brown-800");
+
+    // Navigate to page 2 and verify that the active marking moves along.
+    cy.get("[data-test-id='pagination']")
+      .find('button[aria-label="sida 2"]')
+      .click();
+
+    cy.url().should("include", "p=2");
+
+    cy.get("[data-test-id='pagination']")
+      .find('button[aria-label="sida 2"]')
+      .should("have.class", "bg-brown-800");
+
+    cy.get("[data-test-id='pagination']")
+      .find('button[aria-label="sida 1"]')
+      .should("not.have.class", "bg-brown-800");
+
+    // Navigate back to page 1 and verify that the active marking returns
+    // instead of getting stuck on page 2.
+    cy.get("[data-test-id='pagination']")
+      .find('button[aria-label="sida 1"]')
+      .click();
+
+    cy.url().should("include", "p=1");
+
+    cy.get("[data-test-id='pagination']")
+      .find('button[aria-label="sida 1"]')
+      .should("have.class", "bg-brown-800");
+
+    cy.get("[data-test-id='pagination']")
+      .find('button[aria-label="sida 2"]')
+      .should("not.have.class", "bg-brown-800");
+  });
 });

--- a/features/search/search-results/index.tsx
+++ b/features/search/search-results/index.tsx
@@ -248,7 +248,11 @@ export const SearchResults: FC<SearchResultsProps> = ({
         <Pagination
           totalResults={search.result.count || 0}
           itemsPerPage={search.request.take ? search.request.take : 20}
-          pageNumber={search?.request.page && search?.request.page + 1}
+          pageNumber={
+            search?.request.page !== undefined
+              ? search.request.page + 1
+              : undefined
+          }
           changePage={changePage}
         />
       )}


### PR DESCRIPTION
## Beskrivning

Den nuvarande logiken `search?.request.page && search?.request.page + 1` kortsluter när `search.request.page` är 0 (eftersom 0 utvärderas som falsy). Detta gör att värdet 0 skickas direkt till Paginering-komponenten i stället för 1. Detta triggar en falsy-vakt inuti komponenten vilket leder till att UI-markeringen fastnar på "Sida 2" när en användare navigerar från sida 2 tillbaka till sida 1, trots att rätt sökresultat laddas korrekt under.

Den falsy-vakt som avses finns i `components/pagination/index.tsx`:

```js
useEffect(() => {
  if (pageNumber) {
    setCurrentPage(isNaN(pageNumber) ? 1 : pageNumber);
  }
}, [pageNumber]);
```

När `0` skickas in hoppar denna `if`-sats över uppdateringen helt, och `currentPage` blir kvar på 2.

## Lösning

Ersatt logiken med en explicit kontroll mot `undefined` med en ternär operator, vilket matchar det kodmönster som redan används i `providers/search-provider/index.tsx:671`. Har även lagt till E2E-testtäckning för denna specifika övergång i `search-datasets.cy.ts`.

> **Notering om väljare:** `aria-label` genereras av `${t("pages|search$page")} ${value}` och `pages|search$page` i `locales/sv/pages.json` är gement (`"page": "sida"`). Eftersom CSS-attributväljare är skiftlägeskänsliga använder testet `button[aria-label="sida 2"]`.

## Verifiering

1. Gå till dataportal.se/datasets och sök på ett ord med många träffar (t.ex. "api").
2. Klicka på Sida 2 i pagineringen.
3. Klicka tillbaka till Sida 1.
4. Verifiera att den bruna aktiva markeringen flyttas tillbaka till "1" i stället för att ligga kvar på "2".

## Ändrade filer

- `features/search/search-results/index.tsx` – åtgärdad falsy-kortslutning på `page === 0`.
- `cypress/e2e/search/search-datasets.cy.ts` – nytt E2E-regressionstest för övergången sida 1 → sida 2 → sida 1.