### PR TITLE
DIGG-623: box-based entryscape sidebars + generic resource-page layout

### DIFF
--- a/src/app/[locale]/(entryscape)/_components/data-structures/concept-page/index.tsx
+++ b/src/app/[locale]/(entryscape)/_components/data-structures/concept-page/index.tsx
@@ -4,6 +4,7 @@ import { useTranslations } from "next-intl";
 import { useContext } from "react";
 import { EntryscapeResourcePage } from "@/app/[locale]/(entryscape)/_components/entryscape-resource-page";
 import { Badge } from "@/components/badge";
+import { Box } from "@/components/box";
 import { LabelLink } from "@/components/label-link";
 import { SidebarSection } from "@/components/sidebar-section";
 import { Heading } from "@/components/typography/heading";
@@ -81,10 +82,6 @@ export function ConceptPage() {
         },
       ])}
       title={entry.title}
-      columnsLayout="rowSpaced"
-      mainLayout="content"
-      sidebarLayout="panelRaised"
-      sidebarTestId="about-section"
       intro={
         <>
           <LabelLink
@@ -134,11 +131,11 @@ export function ConceptPage() {
         </>
       }
       sidebar={
-        <>
+        <Box testId="about-section" color="white" padding="xl" rounded={true}>
           <Heading
             level={2}
-            size="sm"
-            className="mb-sm font-strong text-textSecondary md:mb-md"
+            size="md"
+            className="mb-md text-textSecondary md:mb-lg"
           >
             {t("pages.concept_page.about_concept")}
           </Heading>
@@ -168,7 +165,7 @@ export function ConceptPage() {
               testId="download-formats"
             />
           </div>
-        </>
+        </Box>
       }
       footer={
         <>

--- a/src/app/[locale]/(entryscape)/_components/data-structures/data-structure-page/index.tsx
+++ b/src/app/[locale]/(entryscape)/_components/data-structures/data-structure-page/index.tsx
@@ -4,6 +4,7 @@ import { useTranslations } from "next-intl";
 import { useContext } from "react";
 import { EntryscapeResourcePage } from "@/app/[locale]/(entryscape)/_components/entryscape-resource-page";
 import { Badge } from "@/components/badge";
+import { Box } from "@/components/box";
 import { LabelLink } from "@/components/label-link";
 import { SidebarSection } from "@/components/sidebar-section";
 import { Heading } from "@/components/typography/heading";
@@ -71,10 +72,6 @@ export function DataStructurePage({ pageType }: DataStructurePageProps) {
         },
       ])}
       title={entry.title}
-      columnsLayout="rowSpaced"
-      mainLayout="content"
-      sidebarLayout="panelRaised"
-      sidebarTestId="about-section"
       intro={
         <Badge
           text={t(`pages.data-structures.types.${pageType}`)}
@@ -102,11 +99,11 @@ export function DataStructurePage({ pageType }: DataStructurePageProps) {
         </>
       }
       sidebar={
-        <>
+        <Box testId="about-section" color="white" padding="xl" rounded={true}>
           <Heading
             level={2}
-            size="sm"
-            className="mb-sm font-strong text-textSecondary md:mb-md"
+            size="md"
+            className="mb-md text-textSecondary md:mb-lg"
           >
             {t("common.details")}
           </Heading>
@@ -124,7 +121,7 @@ export function DataStructurePage({ pageType }: DataStructurePageProps) {
               testId="download-formats"
             />
           </div>
-        </>
+        </Box>
       }
     />
   );

--- a/src/app/[locale]/(entryscape)/_components/data-structures/data-vocabulary-page/index.tsx
+++ b/src/app/[locale]/(entryscape)/_components/data-structures/data-vocabulary-page/index.tsx
@@ -43,10 +43,6 @@ export function DataVocabularyPage() {
         },
       ])}
       title={entry.title}
-      columnsLayout="rowSpaced"
-      mainLayout="content"
-      sidebarLayout="panels"
-      sidebarTestId="about-section"
       intro={
         <>
           <LabelLink
@@ -94,11 +90,12 @@ export function DataVocabularyPage() {
       }
       sidebar={
         <>
-          <Box color="white" className="mb-lg md:mb-xl">
+          <InteroperableSpecificationsCard labelKey="pages.data-vocabulary.specifications_use" />
+          <Box testId="about-section" color="white" padding="xl" rounded={true}>
             <Heading
               level={2}
-              size="sm"
-              className="mb-sm text-textSecondary md:mb-md"
+              size="md"
+              className="mb-md text-textSecondary md:mb-lg"
             >
               {t("common.details")}
             </Heading>
@@ -122,7 +119,6 @@ export function DataVocabularyPage() {
               />
             </div>
           </Box>
-          <InteroperableSpecificationsCard labelKey="pages.data-vocabulary.specifications_use" />
         </>
       }
     />

--- a/src/app/[locale]/(entryscape)/_components/data-structures/terminology-page/index.tsx
+++ b/src/app/[locale]/(entryscape)/_components/data-structures/terminology-page/index.tsx
@@ -38,10 +38,6 @@ export function TerminologyPage() {
         },
       ])}
       title={entry.title}
-      columnsLayout="rowSpaced"
-      mainLayout="content"
-      sidebarLayout="panels"
-      sidebarTestId="about-section"
       intro={
         <>
           <LabelLink
@@ -79,7 +75,8 @@ export function TerminologyPage() {
       }
       sidebar={
         <>
-          <Box color="white" className="mb-lg md:mb-xl">
+          <InteroperableSpecificationsCard labelKey="pages.terminology.specifications_use" />
+          <Box testId="about-section" color="white" padding="xl" rounded={true}>
             <Heading
               level={2}
               size="sm"
@@ -107,7 +104,6 @@ export function TerminologyPage() {
               />
             </div>
           </Box>
-          <InteroperableSpecificationsCard labelKey="pages.terminology.specifications_use" />
         </>
       }
     />

--- a/src/app/[locale]/(entryscape)/_components/data/data-service-page/index.tsx
+++ b/src/app/[locale]/(entryscape)/_components/data/data-service-page/index.tsx
@@ -42,9 +42,6 @@ export function DataServicePage() {
         },
       ])}
       title={entry.title}
-      columnsLayout="compact"
-      mainLayout="compact"
-      sidebarLayout="panel"
       main={
         <>
           <LabelLink value={entry.relatedResource} />
@@ -58,7 +55,7 @@ export function DataServicePage() {
             data-entryscape-property="dcterms:description"
           />
 
-          <Box color="white" padding="lg">
+          <Box color="white" padding="lg" rounded={true}>
             <div
               data-entryscape="view"
               data-entryscape-onecol="true"
@@ -71,11 +68,11 @@ export function DataServicePage() {
         </>
       }
       sidebar={
-        <>
+        <Box testId="api-section" color="white" padding="xl" rounded={true}>
           <Heading
             level={2}
-            size="sm"
-            className="mb-md font-strong text-textSecondary md:mb-lg"
+            size="md"
+            className="mb-md text-textSecondary md:mb-lg"
           >
             {t("pages.dataservicepage.api")}
           </Heading>
@@ -85,7 +82,7 @@ export function DataServicePage() {
             data-entryscape-rdformsid={ABOUT_FIELDS.join(",")}
             className="lg:w-full space-y-lg"
           />
-        </>
+        </Box>
       }
     />
   );

--- a/src/app/[locale]/(entryscape)/_components/data/dataset-page/index.tsx
+++ b/src/app/[locale]/(entryscape)/_components/data/dataset-page/index.tsx
@@ -5,6 +5,7 @@ import { useContext } from "react";
 import { ContactPublisherBlock } from "@/app/[locale]/(entryscape)/_components/contact-publisher-block";
 import { EntryscapeResourcePage } from "@/app/[locale]/(entryscape)/_components/entryscape-resource-page";
 import { Indicators } from "@/app/[locale]/(entryscape)/_components/indicators";
+import { Box } from "@/components/box";
 import { LabelLink } from "@/components/label-link";
 import { SidebarSection } from "@/components/sidebar-section";
 import { Heading } from "@/components/typography/heading";
@@ -128,14 +129,11 @@ export function DatasetPage() {
       sidebar={
         <>
           {/* About dataset - wrapper  */}
-          <div
-            data-test-id="about-section"
-            className="box-border w-full bg-white p-md"
-          >
+          <Box testId="about-section" color="white" padding="xl" rounded={true}>
             <Heading
               level={2}
-              size={"sm"}
-              className="mb-md font-strong text-textSecondary md:mb-lg"
+              size={"md"}
+              className="mb-md text-textSecondary md:mb-lg"
             >
               {t("pages.datasetpage.about-dataset")}
             </Heading>
@@ -180,17 +178,19 @@ export function DatasetPage() {
                 testId="download-formats"
               />
             </div>
-          </div>
+          </Box>
 
           {/* Catalog information wrapper */}
-          <div
-            data-test-id="catalog-information"
-            className="box-border w-full bg-white p-md"
+          <Box
+            testId="catalog-information"
+            color="white"
+            padding="xl"
+            rounded={true}
           >
             <Heading
               level={2}
-              size={"sm"}
-              className="mb-sm font-strong text-textSecondary md:mb-md"
+              size={"md"}
+              className="mb-md text-textSecondary md:mb-lg"
             >
               {t("pages.datasetpage.catalog")}
             </Heading>
@@ -209,7 +209,7 @@ export function DatasetPage() {
                 data-entryscape-filterpredicates={CATALOG_EXCLUDED.join(",")}
               />
             </div>
-          </div>
+          </Box>
         </>
       }
     />

--- a/src/app/[locale]/(entryscape)/_components/data/dataset-series-page/index.tsx
+++ b/src/app/[locale]/(entryscape)/_components/data/dataset-series-page/index.tsx
@@ -102,7 +102,7 @@ export function DatasetSeriesPage() {
               <Container>
                 <div className="mb-lg gap-2xl md:mb-xl lg:flex">
                   {/* Left column - Search results */}
-                  <div className="mb-lg flex w-full flex-col gap-lg lg:mb-xl lg:max-w-md">
+                  <div className="mb-lg flex w-full flex-col gap-lg lg:mb-xl lg:max-w-md flex-shrink-0">
                     <div
                       className={
                         search.result.hits && search.result.hits.length === 0
@@ -119,7 +119,7 @@ export function DatasetSeriesPage() {
                   </div>
 
                   {/* Right column - About and Catalog */}
-                  <div className="mb-lg w-full max-w-md space-y-lg bg-white pt-none lg:mb-none lg:max-w-[18.5rem]">
+                  <div className="mb-lg w-full max-w-md space-y-lg bg-white pt-none lg:mb-none lg:max-w-[26.25rem]">
                     {/* About dataset series - wrapper */}
                     <div
                       data-test-id="about-section"
@@ -127,8 +127,8 @@ export function DatasetSeriesPage() {
                     >
                       <Heading
                         level={2}
-                        size={"sm"}
-                        className="mb-md font-strong text-textSecondary md:mb-lg"
+                        size={"md"}
+                        className="mb-md text-textSecondary md:mb-lg"
                       >
                         {t("pages.dataset-series.about-dataset-serie")}
                       </Heading>
@@ -138,8 +138,25 @@ export function DatasetSeriesPage() {
                         <div
                           data-entryscape="view"
                           data-entryscape-onecol="true"
+                          data-entryscape-rdformsid="dcat:contactPoint_da"
+                        />
+                        <div
+                          data-entryscape="view"
+                          className="pill-list"
+                          data-entryscape-onecol="true"
+                          data-entryscape-rdformsid="dcat:keyword_da"
+                        />
+                        <div
+                          data-entryscape="view"
+                          className="pill-list"
+                          data-entryscape-onecol="true"
+                          data-entryscape-rdformsid="dcat:theme-da"
+                        />
+                        <div
+                          data-entryscape="view"
+                          data-entryscape-onecol="true"
                           data-entryscape-rdformsid="dcat:DatasetSeries"
-                          data-entryscape-filterpredicates="dcterms:title,dcterms:description"
+                          data-entryscape-filterpredicates="dcterms:title,dcterms:description,dcat:contactPoint,dcterms:spatial,dcat:keyword,dcat:theme"
                         />
                       </div>
                     </div>
@@ -151,8 +168,8 @@ export function DatasetSeriesPage() {
                     >
                       <Heading
                         level={2}
-                        size={"sm"}
-                        className="mb-sm font-strong text-textSecondary md:mb-md"
+                        size={"md"}
+                        className="mb-md text-textSecondary md:mb-lg"
                       >
                         {t("pages.datasetpage.catalog")}
                       </Heading>

--- a/src/app/[locale]/(entryscape)/_components/entryscape-resource-page/index.tsx
+++ b/src/app/[locale]/(entryscape)/_components/entryscape-resource-page/index.tsx
@@ -1,67 +1,10 @@
-import { cva, type VariantProps } from "class-variance-authority";
+import { cx } from "class-variance-authority";
 import type { ReactNode } from "react";
 
 import { Container } from "@/components/layout/container";
 import type { BreadcrumbProps } from "@/components/navigation/breadcrumbs";
 import { BreadcrumbSetter } from "@/components/navigation/breadcrumbs/breadcrumb-setter";
 import { Heading } from "@/components/typography/heading";
-
-export const entryscapeResourcePageColumnsVariants = cva([], {
-  variants: {
-    layout: {
-      default: "mb-lg gap-2xl md:mb-xl lg:flex",
-      compact: "gap-2xl lg:flex",
-      row: "flex flex-col gap-xl md:mb-xl lg:flex-row lg:gap-2xl",
-      rowSpaced: "mb-lg flex flex-col gap-xl md:mb-xl lg:flex-row lg:gap-2xl",
-    },
-  },
-  defaultVariants: {
-    layout: "default",
-  },
-});
-
-export const entryscapeResourcePageMainVariants = cva([], {
-  variants: {
-    layout: {
-      default: "mb-lg flex w-full max-w-md flex-col gap-lg lg:mb-xl",
-      compact: "flex flex-col gap-lg",
-      content: "flex w-full max-w-md flex-col",
-      organisation: "mb-xl flex w-full max-w-md flex-shrink-0 flex-col gap-xl",
-    },
-  },
-  defaultVariants: {
-    layout: "default",
-  },
-});
-
-export const entryscapeResourcePageSidebarVariants = cva([], {
-  variants: {
-    layout: {
-      panels:
-        "mb-lg w-full max-w-md space-y-lg pt-none lg:mb-none lg:max-w-[18.5rem]",
-      panelsWide:
-        "mb-lg w-full max-w-md space-y-lg pt-none lg:mb-none lg:max-w-[26.25rem]",
-      panel:
-        "mb-lg box-border h-fit w-full max-w-md flex-shrink-0 bg-white p-md lg:mb-none lg:max-w-[296px]",
-      panelRaised:
-        "mb-lg h-fit w-full max-w-md bg-white p-md lg:mb-none lg:max-w-[296px]",
-      panelFlush: "h-fit w-full max-w-md bg-white p-md lg:max-w-[296px]",
-    },
-  },
-  defaultVariants: {
-    layout: "panels",
-  },
-});
-
-type ColumnsLayout = VariantProps<
-  typeof entryscapeResourcePageColumnsVariants
->["layout"];
-type MainLayout = VariantProps<
-  typeof entryscapeResourcePageMainVariants
->["layout"];
-type SidebarLayout = VariantProps<
-  typeof entryscapeResourcePageSidebarVariants
->["layout"];
 
 interface EntryscapeResourcePageProps {
   breadcrumb: BreadcrumbProps;
@@ -71,13 +14,9 @@ interface EntryscapeResourcePageProps {
   sidebar: ReactNode;
   footer?: ReactNode;
   head?: ReactNode;
-  columnsLayout?: ColumnsLayout;
-  mainLayout?: MainLayout;
-  sidebarLayout?: SidebarLayout;
   columnsClassName?: string;
   mainClassName?: string;
   sidebarClassName?: string;
-  sidebarTestId?: string;
 }
 
 /**
@@ -93,13 +32,9 @@ export function EntryscapeResourcePage({
   sidebar,
   footer,
   head,
-  columnsLayout,
-  mainLayout,
-  sidebarLayout,
   columnsClassName,
   mainClassName,
   sidebarClassName,
-  sidebarTestId,
 }: EntryscapeResourcePageProps) {
   return (
     <Container>
@@ -112,28 +47,22 @@ export function EntryscapeResourcePage({
           </Heading>
           {intro}
         </div>
-        <div
-          className={entryscapeResourcePageColumnsVariants({
-            layout: columnsLayout,
-            className: columnsClassName,
-          })}
-        >
+        <div className={cx("mb-lg gap-2xl md:mb-xl lg:flex", columnsClassName)}>
           <div
             data-attribute="entryscape-page-main"
-            className={entryscapeResourcePageMainVariants({
-              layout: mainLayout,
-              className: mainClassName,
-            })}
+            className={cx(
+              "mb-lg flex w-full flex-shrink-0 max-w-md flex-col gap-lg lg:mb-xl",
+              mainClassName,
+            )}
           >
             {main}
           </div>
           <div
             data-attribute="entryscape-page-sidebar"
-            className={entryscapeResourcePageSidebarVariants({
-              layout: sidebarLayout,
-              className: sidebarClassName,
-            })}
-            {...(sidebarTestId ? { "data-test-id": sidebarTestId } : {})}
+            className={cx(
+              "mb-lg w-full max-w-md space-y-lg pt-none lg:mb-none lg:max-w-[26.25rem]",
+              sidebarClassName,
+            )}
           >
             {sidebar}
           </div>

--- a/src/app/[locale]/(entryscape)/_components/organisation-page/index.tsx
+++ b/src/app/[locale]/(entryscape)/_components/organisation-page/index.tsx
@@ -35,8 +35,6 @@ export function OrganisationPage() {
         },
       ])}
       title={entry.title}
-      mainLayout="organisation"
-      sidebarLayout="panelsWide"
       main={
         <>
           {/* Description */}
@@ -215,58 +213,53 @@ export function OrganisationPage() {
         </>
       }
       sidebar={
-        <>
-          {/* About dataset - wrapper  */}
-          <Box testId="about-section" color="white" padding="xl" rounded={true}>
-            <Heading
-              level={2}
-              size={"md"}
-              className="mb-md text-textSecondary md:mb-lg break-words hyphens-auto"
-            >
-              {`${t("common.about")} ${entry.title}`}
-            </Heading>
+        <Box testId="about-section" color="white" padding="xl" rounded={true}>
+          <Heading
+            level={2}
+            size={"md"}
+            className="mb-md text-textSecondary md:mb-lg break-words hyphens-auto"
+          >
+            {`${t("common.about")} ${entry.title}`}
+          </Heading>
 
-            <div className="space-y-lg text-sm">
-              <SidebarSection
-                testId="contact"
-                heading={t("pages.organisation_page.contact")}
-                items={[
-                  entry.contact ?? t("pages.organisation_page.no-contact"),
-                ]}
-                color="primary"
-              />
+          <div className="space-y-lg text-sm">
+            <SidebarSection
+              testId="contact"
+              heading={t("pages.organisation_page.contact")}
+              items={[entry.contact ?? t("pages.organisation_page.no-contact")]}
+              color="primary"
+            />
 
-              <SidebarSection
-                testId="organisation-type"
-                heading={t("pages.organisation_page.org-type")}
-                items={[
-                  entry.organisationData?.orgType ||
-                    t("pages.organisation_page.no-org-type"),
-                ]}
-                color="primary"
-              />
+            <SidebarSection
+              testId="organisation-type"
+              heading={t("pages.organisation_page.org-type")}
+              items={[
+                entry.organisationData?.orgType ||
+                  t("pages.organisation_page.no-org-type"),
+              ]}
+              color="primary"
+            />
 
-              <SidebarSection
-                testId="organisation-number"
-                heading={t("pages.organisation_page.org-no")}
-                items={[entry.organisationData?.orgNumber]}
-                color="primary"
-              />
+            <SidebarSection
+              testId="organisation-number"
+              heading={t("pages.organisation_page.org-no")}
+              items={[entry.organisationData?.orgNumber]}
+              color="primary"
+            />
 
-              <SidebarSection
-                testId="mqa-link"
-                heading={t("pages.datasetpage.mqa")}
-                items={[entry.mqaCatalog]}
-              />
+            <SidebarSection
+              testId="mqa-link"
+              heading={t("pages.datasetpage.mqa")}
+              items={[entry.mqaCatalog]}
+            />
 
-              <SidebarSection
-                testId="download-formats"
-                heading={t("pages.organisation_page.download_link")}
-                items={entry.downloadFormats ?? []}
-              />
-            </div>
-          </Box>
-        </>
+            <SidebarSection
+              testId="download-formats"
+              heading={t("pages.organisation_page.download_link")}
+              items={entry.downloadFormats ?? []}
+            />
+          </div>
+        </Box>
       }
       footer={
         entry.organisationData?.showcases &&

--- a/src/app/[locale]/(entryscape)/_components/specification-page/index.tsx
+++ b/src/app/[locale]/(entryscape)/_components/specification-page/index.tsx
@@ -31,9 +31,6 @@ export function SpecificationPage() {
         },
       ])}
       title={entry.title}
-      columnsLayout="row"
-      mainLayout="content"
-      sidebarLayout="panels"
       intro={
         <>
           <LabelLink
@@ -109,11 +106,11 @@ export function SpecificationPage() {
             )}
           </Box>
 
-          <Box testId="about-section" color="white" padding="md">
+          <Box testId="about-section" color="white" padding="xl" rounded={true}>
             <Heading
               level={2}
-              size="sm"
-              className="mb-sm text-textSecondary md:mb-md"
+              size="md"
+              className="mb-md text-textSecondary md:mb-lg"
             >
               {t("pages.specification_page.about_specification")}
             </Heading>

--- a/src/app/[locale]/(entryscape)/_search/search-filters/index.tsx
+++ b/src/app/[locale]/(entryscape)/_search/search-filters/index.tsx
@@ -307,7 +307,7 @@ export function SearchFilters({
           showFilter ? "block" : "hidden"
         }`}
       >
-        <div className="flex h-full flex-col space-y-xl overflow-y-auto overscroll-contain p-lg md:my-xl md:gap-none md:space-y-sm md:p-none">
+        <div className="flex h-full flex-col space-y-xl overflow-y-auto overscroll-contain md:overflow-y-visible p-lg md:my-xl md:gap-none md:space-y-sm md:p-none">
           <ToggleFilterButton className="md:hidden" />
           <span className="!mt-lg border-b border-brown-500 md:hidden" />
           {Object.entries(groupedFacets).map(([groupName, groupFacets]) => (


### PR DESCRIPTION
# Pull Request Description

Fix layout on entryscape pages to be more like organisation page with right sidebar box layout with rounded corners and slightly larger padding.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
