### PR TITLE
Add missing click-maps for entryscape blocks

### DIFF
--- a/src/lib/entryscape-blocks/config.ts
+++ b/src/lib/entryscape-blocks/config.ts
@@ -36,8 +36,17 @@ export const createBlocksConfig = ({
       concept: `${includeLangInPath(lang)}/concepts/\${context}_\${entry}`,
       class: `${includeLangInPath(lang)}/class/\${context}_\${entry}`,
       property: `${includeLangInPath(lang)}/property/\${context}_\${entry}`,
+      datavoc: `${includeLangInPath(lang)}/data-vocabulary/\${context}_\${entry}`,
+      terminology: `${includeLangInPath(lang)}/terminology/\${context}_\${entry}`,
+      organization: `${includeLangInPath(lang)}/organisations/\${context}_\${entry}`,
+      dataset: `${includeLangInPath(lang)}/datasets/\${context}_\${entry}`,
+      spec: `${includeLangInPath(lang)}/specifications/\${context}_\${entry}`,
+      ap: `${includeLangInPath(lang)}/specifications/\${context}_\${entry}/ap`,
       "dataservice-link": `${includeLangInPath(lang)}/dataservice/\${context}_\${entry}`,
       katalog: `${includeLangInPath(lang)}/metadatakvalitet/katalog/\${entry}/\${context}`,
+      conceptSearch: `esb:${includeLangInPath(lang)}/data-structure?f=\${uri}&rt=term`,
+      classSearch: `esb:${includeLangInPath(lang)}/data-structure?f=\${uri}&rt=term_class`,
+      propertySearch: `esb:${includeLangInPath(lang)}/data-structure?f=\${uri}&rt=term_property`,
     },
   };
 


### PR DESCRIPTION
Adds missing entryscape clicks config incl.
* filtered search for data structures on datavoc/terminology and entry type
* click to the upcoming application-profile page
* stable click for specifications

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
